### PR TITLE
Add media index dataset and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# core-iq-demo
+# CORE-IQ Demo
+
+This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
+
+## Usage
+1. Open `index.html` in a browser.
+2. Enter a postcode or ZIP code.
+3. Review the Mosaic groups and media index information.
+
+The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).

--- a/media.json
+++ b/media.json
@@ -1,0 +1,34 @@
+{
+  "B Prestige Positions (15+)": [
+    {
+      "channel": "Digital Display",
+      "index": 1280,
+      "message": "Affluent professionals with high engagement in online advertising."
+    },
+    {
+      "channel": "Print Magazines",
+      "index": 1020,
+      "message": "Regular readers of lifestyle magazines."
+    }
+  ],
+  "A02 Uptown Elite (15+)": [
+    {
+      "channel": "Outdoor Advertising",
+      "index": 1100,
+      "message": "Often commute through premium billboard locations."
+    },
+    {
+      "channel": "Streaming TV",
+      "index": 1250,
+      "message": "Heavy users of subscription streaming services."
+    }
+  ],
+  "K Municipal Tenants (15+)": [
+    {
+      "channel": "Local Radio",
+      "index": 970,
+      "message": "Frequent listeners of community stations."
+    }
+  ]
+}
+

--- a/styles.css
+++ b/styles.css
@@ -67,3 +67,10 @@
 .reset-btn:hover {
   background: #00cc8a;
 }
+
+.insight-subtitle {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add README usage instructions
- include media consumption index data
- fetch new data and render media index entries
- style new heading for media index section

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_685b1154cfb8832d8bea603b2d494dc9