### PR TITLE
Add media insight dataset and clean styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# core-iq-demo
+# CORE-IQ Demo
+
+This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
+
+## Usage
+1. Open `index.html` in a browser.
+2. Enter a postcode or ZIP code.
+3. Review the Mosaic groups and media index information.
+
+The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).

--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      height: 100vh;
+      min-height: 100vh;
       overflow-x: hidden;
+      overflow-y: auto;
       padding: 2rem;
     }
 

--- a/main.js
+++ b/main.js
@@ -1,16 +1,29 @@
 // main.js
 
+// Determine the base path for JSON files so it works when embedded
+// in an iframe or served from a subdirectory.
+const basePath = (() => {
+  const scripts = document.getElementsByTagName('script');
+  const current = scripts[scripts.length - 1].src || '';
+  return current.substring(0, current.lastIndexOf('/') + 1);
+})();
+
 document.getElementById("submitButton").addEventListener("click", () => {
   const rawInput = document.getElementById("postcodeInput").value;
-  const postcode = rawInput.toUpperCase().replace(/\s+/g, '');
+  const postcode = rawInput.toUpperCase().replace(/\s+/g, "");
   const batchFile = determineBatchFile(postcode);
 
-  fetch(`${batchFile}.json`)
-    .then((response) => {
-      if (!response.ok) throw new Error("File not found");
-      return response.json();
-    })
-    .then((data) => {
+  const postcodeData = fetch(`${basePath}${batchFile}.json`).then((r) => {
+    if (!r.ok) throw new Error("File not found");
+    return r.json();
+  });
+
+  const mediaData = fetch(`${basePath}media.json`).then((r) => {
+    if (!r.ok) throw new Error("Media file not found");
+    return r.json();
+  });
+
+  Promise.all([postcodeData, mediaData]).then(([data, media]) => {
       const resultContainer = document.getElementById("resultContainer");
       resultContainer.classList.remove("hidden");
       resultContainer.innerHTML = "";
@@ -24,24 +37,40 @@ document.getElementById("submitButton").addEventListener("click", () => {
       }
 
       const entries = data[postcode];
+      const highSegments = entries.filter((e) => e.type && e.count >= 900);
       let html = `<h2 class="result-heading">Insights for ${postcode}</h2><div class='card-wrap'>`;
 
       // Area 1: Mosaic Segments
-      html += entries.filter(entry => entry.type && entry.count >= 900).map(entry => `
+      html += highSegments
+        .map(
+          (entry) => `
         <div class="insight-card" data-aos="fade-up">
           <div class="insight-title">${entry.type}</div>
-          <div class="insight-index">Count = ${entry.count ?? '—'}</div>
+          <div class="insight-index">Count = ${entry.count ?? "—"}</div>
         </div>
-      `).join('');
+      `
+        )
+        .join("");
 
-      // Area 2: Media Weighting
-      html += entries.filter(entry => entry.channel && entry.index >= 900).map(entry => `
-        <div class="insight-card" data-aos="fade-up">
-          <div class="insight-title">${entry.channel}</div>
-          <div class="insight-index">Index = ${entry.index ?? '—'}</div>
-          <div class="insight-message">${entry.message ?? ''}</div>
-        </div>
-      `).join('');
+      // Area 2: Media Weighting from separate file
+      highSegments.forEach((segment) => {
+        const items = media[segment.type];
+        if (items) {
+          html += `<h3 class='insight-subtitle'>Media Index for ${segment.type}</h3>`;
+          html += items
+            .filter((it) => it.index >= 900)
+            .map(
+              (it) => `
+          <div class="insight-card" data-aos="fade-up">
+            <div class="insight-title">${it.channel}</div>
+            <div class="insight-index">Index = ${it.index ?? "—"}</div>
+            <div class="insight-message">${it.message ?? ""}</div>
+          </div>
+        `
+            )
+            .join("");
+        }
+      });
 
       // Area 3: Summary CTA
       html += `</div><button id="resetButton" class="reset-btn">Try another postcode</button>`;

--- a/media.json
+++ b/media.json
@@ -1,0 +1,34 @@
+{
+  "B Prestige Positions (15+)": [
+    {
+      "channel": "Digital Display",
+      "index": 1280,
+      "message": "Affluent professionals with high engagement in online advertising."
+    },
+    {
+      "channel": "Print Magazines",
+      "index": 1020,
+      "message": "Regular readers of lifestyle magazines."
+    }
+  ],
+  "A02 Uptown Elite (15+)": [
+    {
+      "channel": "Outdoor Advertising",
+      "index": 1100,
+      "message": "Often commute through premium billboard locations."
+    },
+    {
+      "channel": "Streaming TV",
+      "index": 1250,
+      "message": "Heavy users of subscription streaming services."
+    }
+  ],
+  "K Municipal Tenants (15+)": [
+    {
+      "channel": "Local Radio",
+      "index": 970,
+      "message": "Frequent listeners of community stations."
+    }
+  ]
+}
+

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,4 @@
 .card-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-top: 24px;
-}
-
-.insight-card {
-  background: #111;
-  border-left: 4px solid #00ffae;
-  padding: 16px 20px;
-  border-radius: 6px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-  font-family: 'Inter', sans-serif;
-}
-.card-wrap {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
@@ -66,4 +51,11 @@
 
 .reset-btn:hover {
   background: #00cc8a;
+}
+
+.insight-subtitle {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- document usage instructions
- add media index dataset and show it alongside mosaic data
- fetch JSON files relative to script path
- support mobile scrolling
- remove leftover duplicate CSS

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b1154cfb8832d8bea603b2d494dc9