### PR TITLE
Add budget distribution and media index summary

### DIFF
--- a/budget.js
+++ b/budget.js
@@ -1,0 +1,25 @@
+function calculateBudgetDistribution(entries, media, totalBudget) {
+  const weights = {};
+  entries.forEach((seg) => {
+    const segMedia = media[seg.type];
+    if (segMedia) {
+      segMedia.forEach((item) => {
+        if (item.index >= 200) {
+          const key = item.channel;
+          const weight = item.index * seg.count;
+          weights[key] = (weights[key] || 0) + weight;
+        }
+      });
+    }
+  });
+  const totalIndex = Object.values(weights).reduce((sum, w) => sum + w, 0);
+  const distribution = {};
+  for (const [channel, weight] of Object.entries(weights)) {
+    distribution[channel] = {
+      weight,
+      budget: totalIndex ? (weight / totalIndex) * totalBudget : 0,
+    };
+  }
+  return { totalIndex, distribution };
+}
+

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
       color: #ccc;
     }
 
-    input[type="text"] {
+    input[type="text"],
+    input[type="number"] {
       padding: 12px 20px;
       border-radius: 12px;
       border: none;
@@ -131,10 +132,12 @@
     <h1>Find Your Audience Profile</h1>
     <p>Enter your UK postcode or US ZIP code to get matched with your Experian Mosaic group and media consumption insight.</p>
     <input type="text" id="postcodeInput" placeholder="Enter postcode or ZIP" />
+    <input type="number" id="budgetInput" placeholder="Budget (£)" />
     <button id="submitButton">GET INSIGHTS</button>
     <div id="resultContainer" class="hidden"></div>
   </div>
 
+  <script src="budget.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -50,7 +50,7 @@ document.getElementById("submitButton").addEventListener("click", () => {
         if (items) {
           html += `<h3 class='insight-subtitle'>Media Index for ${segment.type}</h3>`;
           html += items
-            .filter((it) => it.index >= 900)
+            .filter((it) => it.index >= 200)
             .map(
               (it) => `
           <div class="insight-card" data-aos="fade-up">
@@ -63,6 +63,20 @@ document.getElementById("submitButton").addEventListener("click", () => {
             .join("");
         }
       });
+
+      const budget = parseFloat(document.getElementById("budgetInput").value) || 0;
+      const { totalIndex, distribution } = calculateBudgetDistribution(entries, media, budget);
+      html += `<h3 class='insight-subtitle'>Total Media Index: ${totalIndex}</h3>`;
+      html += Object.entries(distribution)
+        .map(
+          ([channel, info]) => `
+          <div class="insight-card" data-aos="fade-up">
+            <div class="insight-title">${channel}</div>
+            <div class="insight-index">Budget £${info.budget.toFixed(2)}</div>
+          </div>
+        `
+        )
+        .join("");
 
       // Area 3: Summary CTA
       html += `</div><button id="resetButton" class="reset-btn">Try another postcode</button>`;


### PR DESCRIPTION
## Summary
- lower media index filter to 200 and show total index
- calculate weighted media budget distribution using segment counts
- add number input for budget
- include new budget.js with calculation helper

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685b1e898450832d8b6ef0d68720fac6