### PR TITLE
Add audience and budget inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
 
+The page also lets you describe your target audience and optionally provide a media budget. These inputs are used to surface the best matching Experian Mosaic subgroup and a weighted budget split across recommended media channels.
+
 ## Usage
 1. Open `index.html` in a browser.
 2. Enter a postcode or ZIP code.
-3. Review the Mosaic groups and media index information.
+3. Optionally describe your target audience and set a budget.
+4. Review the suggested Mosaic subgroup, media indices and budget allocation.
 
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).

--- a/budget.js
+++ b/budget.js
@@ -1,0 +1,25 @@
+function calculateBudgetDistribution(entries, media, totalBudget) {
+  const weights = {};
+  entries.forEach((seg) => {
+    const segMedia = media[seg.type];
+    if (segMedia) {
+      segMedia.forEach((item) => {
+        if (item.index >= 200) {
+          const key = item.channel;
+          const weight = item.index * seg.count;
+          weights[key] = (weights[key] || 0) + weight;
+        }
+      });
+    }
+  });
+  const totalIndex = Object.values(weights).reduce((sum, w) => sum + w, 0);
+  const distribution = {};
+  for (const [channel, weight] of Object.entries(weights)) {
+    distribution[channel] = {
+      weight,
+      budget: totalIndex ? (weight / totalIndex) * totalBudget : 0,
+    };
+  }
+  return { totalIndex, distribution };
+}
+

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
       color: #ccc;
     }
 
-    input[type="text"] {
+    input[type="text"],
+    input[type="number"] {
       padding: 12px 20px;
       border-radius: 12px;
       border: none;
@@ -96,6 +97,11 @@
       animation: fadeIn 0.6s ease-out;
     }
 
+    .low-index {
+      border-left-color: #ff5454;
+      box-shadow: 0 0 12px rgba(255, 84, 84, 0.2);
+    }
+
     .insight-title {
       font-weight: 600;
       font-size: 1rem;
@@ -131,10 +137,13 @@
     <h1>Find Your Audience Profile</h1>
     <p>Enter your UK postcode or US ZIP code to get matched with your Experian Mosaic group and media consumption insight.</p>
     <input type="text" id="postcodeInput" placeholder="Enter postcode or ZIP" />
+    <input type="text" id="audienceInput" placeholder="Describe your audience" />
+    <input type="number" id="budgetInput" placeholder="Budget (£)" />
     <button id="submitButton">GET INSIGHTS</button>
     <div id="resultContainer" class="hidden"></div>
   </div>
 
+  <script src="budget.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -15,7 +15,12 @@ document.getElementById("submitButton").addEventListener("click", () => {
     return r.json();
   });
 
-  Promise.all([postcodeData, mediaData]).then(([data, media]) => {
+  const subgroupData = fetch("subgroups.json").then((r) => {
+    if (!r.ok) throw new Error("Subgroup file not found");
+    return r.json();
+  });
+
+  Promise.all([postcodeData, mediaData, subgroupData]).then(([data, media, subgroups]) => {
       const resultContainer = document.getElementById("resultContainer");
       resultContainer.classList.remove("hidden");
       resultContainer.innerHTML = "";
@@ -30,7 +35,16 @@ document.getElementById("submitButton").addEventListener("click", () => {
 
       const entries = data[postcode];
       const highSegments = entries.filter((e) => e.type && e.count >= 900);
+      const audienceText = document.getElementById("audienceInput").value.toLowerCase();
+      const bestGroup = findBestSubgroup(subgroups, audienceText);
       let html = `<h2 class="result-heading">Insights for ${postcode}</h2><div class='card-wrap'>`;
+      if (bestGroup) {
+        html += `
+        <div class="insight-card" data-aos="fade-up">
+          <div class="insight-title">Top Mosaic Match: ${bestGroup.group}</div>
+          <div class="insight-index">Index = ${bestGroup.index}</div>
+        </div>`;
+      }
 
       // Area 1: Mosaic Segments
       html += highSegments
@@ -50,19 +64,36 @@ document.getElementById("submitButton").addEventListener("click", () => {
         if (items) {
           html += `<h3 class='insight-subtitle'>Media Index for ${segment.type}</h3>`;
           html += items
-            .filter((it) => it.index >= 900)
+            .filter((it) => it.index >= 200)
             .map(
-              (it) => `
-          <div class="insight-card" data-aos="fade-up">
+              (it) => {
+                const cardClass = it.index < 100 ? "insight-card low-index" : "insight-card";
+                return `
+          <div class="${cardClass}" data-aos="fade-up">
             <div class="insight-title">${it.channel}</div>
             <div class="insight-index">Index = ${it.index ?? "—"}</div>
             <div class="insight-message">${it.message ?? ""}</div>
           </div>
-        `
+        `;
+              }
             )
             .join("");
         }
       });
+
+      const budget = parseFloat(document.getElementById("budgetInput").value) || 0;
+      const { totalIndex, distribution } = calculateBudgetDistribution(entries, media, budget);
+      html += `<h3 class='insight-subtitle'>Total Media Index: ${totalIndex}</h3>`;
+      html += Object.entries(distribution)
+        .map(
+          ([channel, info]) => `
+          <div class="insight-card" data-aos="fade-up">
+            <div class="insight-title">${channel}</div>
+            <div class="insight-index">Budget £${info.budget.toFixed(2)}</div>
+          </div>
+        `
+        )
+        .join("");
 
       // Area 3: Summary CTA
       html += `</div><button id="resetButton" class="reset-btn">Try another postcode</button>`;
@@ -93,5 +124,27 @@ function determineBatchFile(postcode) {
     S: "9", T: "9", U: "9", V: "9", W: "9", X: "9", Y: "9", Z: "9"
   };
   return map[firstLetter] || "1";
+}
+
+function findBestSubgroup(subgroups, text) {
+  let best = null;
+  let bestScore = -1;
+  subgroups.forEach((group) => {
+    let score = 0;
+    if (group.gender && text.includes(group.gender)) score++;
+    if (group.location && text.includes(group.location.toLowerCase())) score++;
+    if (group.occupation && text.includes(group.occupation.toLowerCase())) score++;
+    if (group.card && text.includes(group.card.toLowerCase())) score++;
+    if (group.interests) {
+      group.interests.forEach((i) => {
+        if (text.includes(i)) score++;
+      });
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      best = group;
+    }
+  });
+  return best;
 }
 

--- a/subgroups.json
+++ b/subgroups.json
@@ -1,0 +1,29 @@
+[
+  {
+    "group": "SG1 Fitness Females",
+    "gender": "female",
+    "interests": ["gym", "yoga"],
+    "card": "virgin credit card",
+    "occupation": "finance",
+    "location": "Cardiff",
+    "index": 120
+  },
+  {
+    "group": "SG2 Urban Professionals",
+    "gender": "male",
+    "interests": ["basketball"],
+    "card": "amex",
+    "occupation": "technology",
+    "location": "London",
+    "index": 110
+  },
+  {
+    "group": "SG3 Rural Families",
+    "gender": "female",
+    "interests": ["gardening"],
+    "card": "visa",
+    "occupation": "education",
+    "location": "York",
+    "index": 95
+  }
+]


### PR DESCRIPTION
## Summary
- add instructions for new audience and budget fields in README
- show the new text and number inputs in `index.html`
- compute weighted budget split for channels in `main.js`
- store sample subgroup data to match the audience description
- use `calculateBudgetDistribution` in `budget.js` to spread budget based on media index

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685b1e898450832d8b6ef0d68720fac6