### PR TITLE
Fix budget input props

### DIFF
--- a/budget.js
+++ b/budget.js
@@ -23,3 +23,5 @@ function calculateBudgetDistribution(entries, media, totalBudget) {
   return { totalIndex, distribution };
 }
 
+
+if (typeof module !== "undefined") module.exports = { calculateBudgetDistribution };

--- a/budget.test.js
+++ b/budget.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const { calculateBudgetDistribution } = require('./budget');
+
+const entries = [{ type: 'A', count: 1000 }];
+const media = { A: [{ channel: 'TV', index: 250 }] };
+const result = calculateBudgetDistribution(entries, media, 100);
+
+assert.strictEqual(result.totalIndex, 250000);
+assert.ok(result.distribution.TV, 'TV distribution missing');
+assert(Math.abs(result.distribution.TV.budget - 100) < 1e-6);
+
+console.log('All tests passed');

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
     <h1>Find Your Audience Profile</h1>
     <p>Enter your UK postcode or US ZIP code to get matched with your Experian Mosaic group and media consumption insight.</p>
     <input type="text" id="postcodeInput" placeholder="Enter postcode or ZIP" />
-    <input type="number" id="budgetInput" placeholder="Budget (£)" />
+    <input type="number" id="budgetInput" placeholder="Budget (£)" min="0" step="0.01" />
     <button id="submitButton">GET INSIGHTS</button>
     <div id="resultContainer" class="hidden"></div>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "core-iq-demo",
+  "version": "1.0.0",
+  "description": "Demo for CORE-IQ audience insights",
+  "main": "index.html",
+  "scripts": {
+    "test": "node budget.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- enable decimals for budget input
- add Node-based test runner to ensure budget distribution works as expected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bb3a2e880832db8e64614d9edd7c9