### PR TITLE
Implement top segment sorting and update budget calculations

### DIFF
--- a/budget.js
+++ b/budget.js
@@ -4,7 +4,7 @@ function calculateBudgetDistribution(entries, media, totalBudget) {
     const segMedia = media[seg.type];
     if (segMedia) {
       segMedia.forEach((item) => {
-        if (item.index >= 200) {
+        if (item.index > 300) {
           const key = item.channel;
           const weight = item.index * seg.count;
           weights[key] = (weights[key] || 0) + weight;

--- a/budget.test.js
+++ b/budget.test.js
@@ -2,10 +2,10 @@ const assert = require('assert');
 const { calculateBudgetDistribution } = require('./budget');
 
 const entries = [{ type: 'A', count: 1000 }];
-const media = { A: [{ channel: 'TV', index: 250 }] };
+const media = { A: [{ channel: 'TV', index: 400 }] };
 const result = calculateBudgetDistribution(entries, media, 100);
 
-assert.strictEqual(result.totalIndex, 250000);
+assert.strictEqual(result.totalIndex, 400000);
 assert.ok(result.distribution.TV, 'TV distribution missing');
 assert(Math.abs(result.distribution.TV.budget - 100) < 1e-6);
 

--- a/main.js
+++ b/main.js
@@ -29,11 +29,14 @@ document.getElementById("submitButton").addEventListener("click", () => {
       }
 
       const entries = data[postcode];
-      const highSegments = entries.filter((e) => e.type && e.count >= 900);
+      const topSegments = entries
+        .filter((e) => e.type)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 3);
       let html = `<h2 class="result-heading">Insights for ${postcode}</h2><div class='card-wrap'>`;
 
       // Area 1: Mosaic Segments
-      html += highSegments
+      html += topSegments
         .map(
           (entry) => `
         <div class="insight-card" data-aos="fade-up">
@@ -45,7 +48,7 @@ document.getElementById("submitButton").addEventListener("click", () => {
         .join("");
 
       // Area 2: Media Weighting from separate file
-      highSegments.forEach((segment) => {
+      topSegments.forEach((segment) => {
         const items = media[segment.type];
         if (items) {
           html += `<h3 class='insight-subtitle'>Media Index for ${segment.type}</h3>`;
@@ -65,7 +68,7 @@ document.getElementById("submitButton").addEventListener("click", () => {
       });
 
       const budget = parseFloat(document.getElementById("budgetInput").value) || 0;
-      const { totalIndex, distribution } = calculateBudgetDistribution(entries, media, budget);
+      const { totalIndex, distribution } = calculateBudgetDistribution(topSegments, media, budget);
       html += `<h3 class='insight-subtitle'>Total Media Index: ${totalIndex}</h3>`;
       html += Object.entries(distribution)
         .map(


### PR DESCRIPTION
## Summary
- display only the top three segments by count
- route the selected segments to the budget calculation
- ignore media items with index ≤300 during budget distribution
- fix tests for new index cutoff

## Testing
- `node budget.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685bb986ae98832dbdf3adade98bf694