### PR TITLE
Enable variable search

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,8 +130,8 @@
 <body>
   <div class="glow-container">
     <h1>Find Your Audience Profile</h1>
-    <p>Enter your UK postcode or US ZIP code to get matched with your Experian Mosaic group and media consumption insight.</p>
-    <input type="text" id="postcodeInput" placeholder="Enter postcode or ZIP" />
+    <p>Enter your UK postcode, US ZIP code or any search term to get matched with your Experian Mosaic group and media consumption insight.</p>
+    <input type="text" id="postcodeInput" placeholder="Enter postcode, ZIP or search term" />
     <input type="number" id="budgetInput" placeholder="Budget (£)" min="0" step="0.01" />
     <button id="submitButton">GET INSIGHTS</button>
     <div id="resultContainer" class="hidden"></div>

--- a/main.js
+++ b/main.js
@@ -2,7 +2,8 @@
 
 document.getElementById("submitButton").addEventListener("click", () => {
   const rawInput = document.getElementById("postcodeInput").value;
-  const postcode = rawInput.toUpperCase().replace(/\s+/g, "");
+  const query = rawInput.toUpperCase().trim();
+  const postcode = query.replace(/\s+/g, "");
   const batchFile = determineBatchFile(postcode);
 
   const postcodeData = fetch(`${batchFile}.json`).then((r) => {
@@ -21,10 +22,7 @@ document.getElementById("submitButton").addEventListener("click", () => {
       resultContainer.innerHTML = "";
 
       if (!data[postcode]) {
-        resultContainer.innerHTML = `
-          <div class="centered-card">
-            <p>No data found for postcode <strong>${postcode}</strong>.</p>
-          </div>`;
+        searchVariable(query, resultContainer);
         return;
       }
 
@@ -87,7 +85,7 @@ document.getElementById("submitButton").addEventListener("click", () => {
         .join("");
 
       // Area 3: Summary CTA
-      html += `</div><button id="resetButton" class="reset-btn">Try another postcode</button>`;
+      html += `</div><button id="resetButton" class="reset-btn">Try another search</button>`;
       resultContainer.innerHTML = html;
 
       document.getElementById("resetButton").addEventListener("click", () => {
@@ -105,6 +103,71 @@ document.getElementById("submitButton").addEventListener("click", () => {
       document.getElementById("resultContainer").innerHTML = `<p>There was an error loading insights.</p>`;
     });
 });
+
+function searchVariable(query, container) {
+  const files = [
+    "mosaic_regional_distributions.json",
+    "mosaic_family_tree_manual.json",
+    "mosaic_rankings.json",
+    "grand_index_means.json",
+    "key_features (1).json",
+    "primary_content (1).json",
+    "grand_index_indices_clean.json",
+  ];
+
+  const fetches = files.map((f) =>
+    fetch(f)
+      .then((r) => (r.ok ? r.json() : []))
+      .catch(() => [])
+  );
+
+  Promise.all(fetches)
+    .then((datasets) => {
+      const data = datasets.flat();
+      const results = data.filter((entry) =>
+        Object.values(entry).some(
+          (v) => typeof v === "string" && v.toUpperCase().includes(query)
+        )
+      );
+
+      if (results.length === 0) {
+        container.innerHTML = `
+          <div class="centered-card">
+            <p>No results found for <strong>${query}</strong>.</p>
+          </div>`;
+        return;
+      }
+
+      let html = `<h2 class="result-heading">Results for ${query}</h2><div class='card-wrap'>`;
+      html += results
+        .slice(0, 5)
+        .map(
+          (e) => `
+        <div class="insight-card">
+          <div class="insight-title">${e["Unnamed: 1"] ?? ""} ${e["Unnamed: 2"] ?? ""}</div>
+          <div class="insight-message">${e["Unnamed: 3"] ?? ""}</div>
+        </div>`
+        )
+        .join("");
+      html += `</div><button id="resetButton" class="reset-btn">Try another search</button>`;
+
+      container.innerHTML = html;
+
+      document.getElementById("resetButton").addEventListener("click", () => {
+        document.getElementById("postcodeInput").value = "";
+        container.classList.add("hidden");
+        container.innerHTML = "";
+        document.getElementById("postcodeInput").focus();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+
+      window.scrollTo({ top: container.offsetTop - 50, behavior: 'smooth' });
+    })
+    .catch((error) => {
+      console.error("Variable search error:", error);
+      container.innerHTML = `<p>There was an error searching data.</p>`;
+    });
+}
 
 function determineBatchFile(postcode) {
   const firstLetter = postcode[0].toUpperCase();


### PR DESCRIPTION
## Summary
- allow searching by general terms rather than just postcode
- show results from the new data files when postcode lookup fails
- update input helper text and button label
- search variable data across newly renamed json files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bcfd255ec832da795bddafc82092a