### PR TITLE
Add dynamic results page

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
   </section>
 
   <script src="budget.js"></script>
-  <script src="main.js"></script>
+  <script src="results.js"></script>
 </body>
 </html>
 

--- a/results.js
+++ b/results.js
@@ -1,0 +1,108 @@
+function renderAudienceResults(data) {
+  const container = document.getElementById('resultContainer');
+  container.classList.remove('hidden');
+  container.innerHTML = '';
+
+  const heading = document.createElement('h2');
+  heading.className = 'result-heading';
+  heading.textContent = data.mosaic_group;
+  container.appendChild(heading);
+
+  const desc = document.createElement('p');
+  desc.textContent = data.description;
+  container.appendChild(desc);
+
+  // Demographics
+  const demoSection = document.createElement('section');
+  const demoTitle = document.createElement('h3');
+  demoTitle.textContent = 'Demographic Indices';
+  demoSection.appendChild(demoTitle);
+  const demoList = document.createElement('ul');
+  data.demographics.forEach((d) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${d.label}:</strong> ${d.value} <span class="index-val" data-index="${d.index}">${d.index}</span>`;
+    demoList.appendChild(li);
+  });
+  demoSection.appendChild(demoList);
+  container.appendChild(demoSection);
+
+  // Key features
+  const featureSection = document.createElement('section');
+  const featureTitle = document.createElement('h3');
+  featureTitle.textContent = 'Key Features';
+  featureSection.appendChild(featureTitle);
+  const featureList = document.createElement('ul');
+  data.key_features.forEach((f) => {
+    const li = document.createElement('li');
+    li.textContent = f;
+    featureList.appendChild(li);
+  });
+  featureSection.appendChild(featureList);
+  container.appendChild(featureSection);
+
+  // Media channels
+  const mediaSection = document.createElement('section');
+  const mediaTitle = document.createElement('h3');
+  mediaTitle.textContent = 'Media Channel Effectiveness';
+  mediaSection.appendChild(mediaTitle);
+  const mediaList = document.createElement('ul');
+  data.media_channels.forEach((m) => {
+    const li = document.createElement('li');
+    li.innerHTML = `${m.label} <span class="index-val" data-index="${m.index}">${m.index}</span>`;
+    mediaList.appendChild(li);
+  });
+  mediaSection.appendChild(mediaList);
+  container.appendChild(mediaSection);
+
+  // Postcodes
+  const postSection = document.createElement('section');
+  const postTitle = document.createElement('h3');
+  postTitle.textContent = 'Postcode Reach';
+  postSection.appendChild(postTitle);
+  const postList = document.createElement('ul');
+  data.top_postcodes.forEach((p) => {
+    const li = document.createElement('li');
+    li.textContent = `${p.code} - ${p.count}`;
+    postList.appendChild(li);
+  });
+  postSection.appendChild(postList);
+  container.appendChild(postSection);
+
+  // Media plan
+  const planSection = document.createElement('section');
+  const planTitle = document.createElement('h3');
+  planTitle.textContent = 'Weighted Media Budget Allocation';
+  planSection.appendChild(planTitle);
+  const planList = document.createElement('ul');
+  data.media_plan_allocation.forEach((p) => {
+    const budget = p.index < 100 ? 0 : p.budget;
+    const li = document.createElement('li');
+    li.innerHTML = `${p.channel}: <span class="index-val" data-index="${p.index}">${p.index}</span> - £${budget}`;
+    planList.appendChild(li);
+  });
+  planSection.appendChild(planList);
+  container.appendChild(planSection);
+
+  applyIndexStyles(container);
+}
+
+function applyIndexStyles(container) {
+  const spans = container.querySelectorAll('.index-val');
+  spans.forEach((el) => {
+    const val = parseFloat(el.dataset.index);
+    if (val > 100) {
+      el.style.color = '#00ffae';
+      el.style.textShadow = '0 0 6px #00ffae';
+    } else {
+      el.style.color = 'red';
+      el.style.textShadow = '0 0 6px red';
+    }
+  });
+}
+
+// Example usage loading JSON
+fetch('sample_result.json')
+  .then((r) => r.json())
+  .then((data) => {
+    renderAudienceResults(data);
+  });

--- a/sample_result.json
+++ b/sample_result.json
@@ -1,0 +1,21 @@
+{
+  "mosaic_group": "City Prosperity (Group A)",
+  "description": "High-status city dwellers...",
+  "demographics": [
+    { "label": "Age", "value": "26–35", "index": 139 },
+    { "label": "Household Income", "value": "£100K–£149.9K", "index": 420 }
+  ],
+  "key_features": ["Urban areas", "High-value flats"],
+  "media_channels": [
+    { "label": "TV", "index": 130 },
+    { "label": "Internet", "index": 96 }
+  ],
+  "top_postcodes": [
+    { "code": "LS14", "count": 1204 },
+    { "code": "NG8", "count": 992 }
+  ],
+  "media_plan_allocation": [
+    { "channel": "Paid Social", "index": 143, "budget": 6820 },
+    { "channel": "Radio", "index": 84, "budget": 0 }
+  ]
+}


### PR DESCRIPTION
## Summary
- add new JSON output example
- render dynamic audience results from JSON with new script
- load new results script instead of the previous demo script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c2a30e2e8832d8c2c72ddbe4d8164