### PR TITLE
Enable results page redirect

### DIFF
--- a/results.js
+++ b/results.js
@@ -100,9 +100,15 @@ function applyIndexStyles(container) {
   });
 }
 
-// Example usage loading JSON
-fetch('sample_result.json')
-  .then((r) => r.json())
-  .then((data) => {
-    renderAudienceResults(data);
-  });
+const stored = localStorage.getItem('audienceResult');
+if (stored) {
+  const data = JSON.parse(stored);
+  renderAudienceResults(data);
+} else {
+  // Fallback to sample data when no stored result exists
+  fetch('sample_result.json')
+    .then((r) => r.json())
+    .then((data) => {
+      renderAudienceResults(data);
+    });
+}


### PR DESCRIPTION
## Summary
- clear old audienceResult before each search
- load additional JSON data for groups and features
- build an object with media plan details and store it in `localStorage`
- redirect to `results.html` for detailed results
- pull stored data from localStorage inside `results.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5ecf7400832dad75e1154978186e