### PR TITLE
Fix search data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
 
 ## Usage
-1. Open `index.html` in a browser.
-2. Enter a postcode or ZIP code.
-3. Review the Mosaic groups and media index information.
+1. Install Node.js if you have not already.
+2. Run `npm start` from the project root to launch a small local server.
+3. Open `http://localhost:8000` in your browser.
+4. Enter a postcode or search term to view the Mosaic groups and weighted media budget.
 
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Demo for CORE-IQ audience insights",
   "main": "index.html",
   "scripts": {
-    "test": "node budget.test.js"
+    "test": "node budget.test.js",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,31 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 8000;
+
+const server = http.createServer((req, res) => {
+  const safePath = path.normalize(req.url).replace(/^\/+/, '');
+  const filePath = path.join(__dirname, safePath || 'index.html');
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json'
+  }[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- add simple Node.js static server for loading JSON files
- document running the server in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6362d5c8832d9412c2e48e0da7e4