### PR TITLE
Add OpenAI query route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This is a lightweight demo that displays audience insights by UK postcode or US 
 3. Open `http://localhost:8000` in your browser.
 4. Enter a postcode or search term to view the Mosaic groups and weighted media budget.
 
+### OpenAI integration
+To enable natural language queries processed via OpenAI, set an environment variable `OPENAI_API_KEY` before starting the server:
+
+```bash
+export OPENAI_API_KEY=your-key-here
+npm start
+```
+
+When a search term does not match local data, the server will forward the query and a snippet of the JSON files to OpenAI and display the response.
+
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
 
 Animations rely on simple CSS transitions, so no external libraries such as AOS are required.

--- a/main.js
+++ b/main.js
@@ -159,10 +159,7 @@ function searchVariable(query, container) {
       );
 
       if (results.length === 0) {
-        container.innerHTML = `
-          <div class="centered-card">
-            <p>No results found for <strong>${query}</strong>.</p>
-          </div>`;
+        queryOpenAI(query, container);
         return;
       }
 
@@ -214,5 +211,21 @@ function findMediaItems(segmentType, mediaData) {
   const code = segmentType[0];
   const matchKey = Object.keys(mediaData).find((k) => k.startsWith(code));
   return mediaData[matchKey];
+}
+
+function queryOpenAI(query, container) {
+  fetch('/api/openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query })
+  })
+    .then(r => r.json())
+    .then(data => {
+      container.innerHTML = `<div class="insight-card">${data.answer}</div>`;
+    })
+    .catch(err => {
+      console.error('OpenAI request failed', err);
+      container.innerHTML = `<p>There was an error processing your query.</p>`;
+    });
 }
 


### PR DESCRIPTION
## Summary
- wire up a `/api/openai` endpoint to call OpenAI's chat API
- call this endpoint from the search JS when no local data matches
- document how to use the new integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3ea4ec48832dbfb34e194fa54ee4