### PR TITLE
Improve postcode search and budget calculation

### DIFF
--- a/budget.js
+++ b/budget.js
@@ -1,10 +1,16 @@
 function calculateBudgetDistribution(entries, media, totalBudget) {
   const weights = {};
   entries.forEach((seg) => {
-    const segMedia = media[seg.type];
+    let segMedia = media[seg.type];
+    if (!segMedia) {
+      const prefix = seg.type[0];
+      const matchKey = Object.keys(media).find((k) => k.startsWith(prefix));
+      segMedia = media[matchKey];
+    }
     if (segMedia) {
       segMedia.forEach((item) => {
-        if (item.index > 90) {
+        // Only allocate budget to channels with an index over 100
+        if (item.index > 100) {
           const key = item.channel;
           const weight = item.index * seg.count;
           weights[key] = (weights[key] || 0) + weight;

--- a/budget.test.js
+++ b/budget.test.js
@@ -2,11 +2,19 @@ const assert = require('assert');
 const { calculateBudgetDistribution } = require('./budget');
 
 const entries = [{ type: 'A', count: 1000 }];
-const media = { A: [{ channel: 'TV', index: 350 }] };
+const media = { 'A - Group': [
+  { channel: 'TV', index: 350 },
+  { channel: 'Radio', index: 90 }
+] };
+const entriesMismatch = [{ type: 'B Segment', count: 500 }];
+const mediaMismatch = { 'B - Segment': [ { channel: 'Web', index: 200 } ] };
 const result = calculateBudgetDistribution(entries, media, 100);
+const mismatchResult = calculateBudgetDistribution(entriesMismatch, mediaMismatch, 100);
 
 assert.strictEqual(result.totalIndex, 350000);
 assert.ok(result.distribution.TV, 'TV distribution missing');
+assert.strictEqual(result.distribution.Radio, undefined, 'Radio should be excluded');
 assert(Math.abs(result.distribution.TV.budget - 100) < 1e-6);
+assert.strictEqual(mismatchResult.distribution.Web.budget, 100, 'Web spend not allocated');
 
 console.log('All tests passed');

--- a/results.html
+++ b/results.html
@@ -26,8 +26,8 @@
   </style>
 </head>
 <body>
-  <section style="background: linear-gradient(to bottom, #000, #0a0a0a); min-height: 100vh; padding: 40px 20px;">
-    <div id="resultContainer" class="hidden"></div>
+  <section id="resultsSection" style="background: linear-gradient(to bottom, #000, #0a0a0a); min-height: 100vh; padding: 60px 20px;">
+    <div id="resultsRoot" style="max-width: 1200px; margin: auto; display: flex; flex-direction: column; gap: 40px;"></div>
   </section>
 
   <script src="results.js"></script>

--- a/results.js
+++ b/results.js
@@ -1,114 +1,67 @@
 function renderAudienceResults(data) {
-  const container = document.getElementById('resultContainer');
-  container.classList.remove('hidden');
-  container.innerHTML = '';
+  const root = document.getElementById('resultsRoot');
+  if (!root) return;
+  root.innerHTML = '';
 
-  const heading = document.createElement('h2');
-  heading.className = 'result-heading';
-  heading.textContent = data.mosaic_group;
-  container.appendChild(heading);
+  const html = `
+    <div style="text-align: center;">
+      <h2 style="font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; color: #00ffae;">${data.mosaic_group}</h2>
+      <p style="color: #aaa; font-size: 1.2rem; max-width: 720px; margin: 12px auto 0;">${data.description}</p>
+    </div>
+    <div style="background: #111; border-left: 4px solid #00ffae; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);">
+      <h3 style="color: #00ffae; margin-bottom: 8px;">What is an Index?</h3>
+      <p style="margin: 0; color: #ccc;">An index score compares this group’s likelihood of a behaviour or trait against the UK average (100). An index of 130 means this group is 30% more likely than average to exhibit that trait.</p>
+    </div>
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 24px;">
+      ${data.demographics.map(d => `<div style="background: #111; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);"><p style="color: #00ffae; font-weight: 600; margin-bottom: 4px;">${d.label}</p><p>${d.value} <span style="color:#aaa">(Index: ${d.index})</span></p></div>`).join('')}
+    </div>
+    <div style="background: #111; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);">
+      <h4 style="color: #00ffae; margin-bottom: 12px;">Key Features</h4>
+      <ul style="margin: 0; padding-left: 20px; color: #ccc; line-height: 1.6;">
+        ${data.key_features.map(f => `<li>${f}</li>`).join('')}
+      </ul>
+    </div>
+    <div>
+      <h3 style="font-size: 1.5rem; font-weight: 700; color: #00ffae;">Media Channel Effectiveness</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 24px; margin-top: 20px;">
+        ${data.media_channels.map(m => {
+          const high = m.index > 100;
+          const color = high ? '#00ffae' : 'red';
+          const shadow = high ? '0 0 24px rgba(0,255,174,0.5)' : '0 0 24px rgba(255,0,0,0.5)';
+          return `<div style="background: #111; border-radius: 12px; padding: 20px; text-align: center; box-shadow: ${shadow};"><p style="margin: 0; color: #ccc;">${m.label}</p><p style="color: #aaa; font-size: 0.9rem; margin: 4px 0;">Index: ${m.index}</p><p style="color: ${color}; font-weight: bold;">${m.index}</p></div>`;
+        }).join('')}
+      </div>
+    </div>
+    <div style="background: #111; border-left: 4px solid #00ffae; border-radius: 16px; padding: 32px; box-shadow: 0 0 24px rgba(0,255,174,0.2);">
+      <h3 style="font-size: 1.6rem; font-weight: 800; color: #00ffae; margin-bottom: 20px; text-align: center;">\uD83D\uDCCD Postcode Reach & \uD83C\uDF09 Media Plan Allocation</h3>
+      <div style="margin-bottom: 32px;">
+        <h4 style="color: #ccc; font-size: 1.2rem; font-weight: 600; margin-bottom: 12px;">Top Performing Postcode Areas:</h4>
+        <ul style="list-style: none; padding-left: 0; color: #fff; display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px;">
+          ${data.top_postcodes.map(p => `<li style="background:#000; padding: 16px; border-radius: 12px; box-shadow: 0 0 12px rgba(0,255,174,0.2);"><strong>${p.code}:</strong> ${p.count} households</li>`).join('')}
+        </ul>
+      </div>
+      <div>
+        <h4 style="color: #ccc; font-size: 1.2rem; font-weight: 600; margin-bottom: 12px;">Media Channel Effectiveness & Spend:</h4>
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 20px;">
+          ${data.media_plan_allocation.map(p => {
+            const high = p.index > 100;
+            const bg = high ? '#001f1a' : '#1a0000';
+            const border = high ? '#00ffae' : 'red';
+            const text = high ? '#00ffae' : 'red';
+            const budget = high ? p.budget : 0;
+            return `<div style="background: ${bg}; border-left: 4px solid ${border}; padding: 20px; border-radius: 12px;"><p style="color: ${text}; font-weight: 600; margin: 0 0 8px;">${p.channel}</p><p style="margin: 0; color: #ccc;">Index: <strong>${p.index}</strong></p><p style="margin: 0; color: #ccc;">Budget Allocation: <strong>£${budget.toFixed(2)}</strong></p></div>`;
+          }).join('')}
+        </div>
+      </div>
+    </div>
+  `;
 
-  const desc = document.createElement('p');
-  desc.textContent = data.description;
-  container.appendChild(desc);
-
-  // Demographics
-  const demoSection = document.createElement('section');
-  const demoTitle = document.createElement('h3');
-  demoTitle.textContent = 'Demographic Indices';
-  demoSection.appendChild(demoTitle);
-  const demoList = document.createElement('ul');
-  data.demographics.forEach((d) => {
-    const li = document.createElement('li');
-    li.innerHTML = `<strong>${d.label}:</strong> ${d.value} <span class="index-val" data-index="${d.index}">${d.index}</span>`;
-    demoList.appendChild(li);
-  });
-  demoSection.appendChild(demoList);
-  container.appendChild(demoSection);
-
-  // Key features
-  const featureSection = document.createElement('section');
-  const featureTitle = document.createElement('h3');
-  featureTitle.textContent = 'Key Features';
-  featureSection.appendChild(featureTitle);
-  const featureList = document.createElement('ul');
-  data.key_features.forEach((f) => {
-    const li = document.createElement('li');
-    li.textContent = f;
-    featureList.appendChild(li);
-  });
-  featureSection.appendChild(featureList);
-  container.appendChild(featureSection);
-
-  // Media channels
-  const mediaSection = document.createElement('section');
-  const mediaTitle = document.createElement('h3');
-  mediaTitle.textContent = 'Media Channel Effectiveness';
-  mediaSection.appendChild(mediaTitle);
-  const mediaList = document.createElement('ul');
-  data.media_channels.forEach((m) => {
-    const li = document.createElement('li');
-    li.innerHTML = `${m.label} <span class="index-val" data-index="${m.index}">${m.index}</span>`;
-    mediaList.appendChild(li);
-  });
-  mediaSection.appendChild(mediaList);
-  container.appendChild(mediaSection);
-
-  // Postcodes
-  const postSection = document.createElement('section');
-  const postTitle = document.createElement('h3');
-  postTitle.textContent = 'Postcode Reach';
-  postSection.appendChild(postTitle);
-  const postList = document.createElement('ul');
-  data.top_postcodes.forEach((p) => {
-    const li = document.createElement('li');
-    li.textContent = `${p.code} - ${p.count}`;
-    postList.appendChild(li);
-  });
-  postSection.appendChild(postList);
-  container.appendChild(postSection);
-
-  // Media plan
-  const planSection = document.createElement('section');
-  const planTitle = document.createElement('h3');
-  planTitle.textContent = 'Weighted Media Budget Allocation';
-  planSection.appendChild(planTitle);
-  const planList = document.createElement('ul');
-  data.media_plan_allocation.forEach((p) => {
-    const budget = p.index < 100 ? 0 : p.budget;
-    const li = document.createElement('li');
-    li.innerHTML = `${p.channel}: <span class="index-val" data-index="${p.index}">${p.index}</span> - £${budget}`;
-    planList.appendChild(li);
-  });
-  planSection.appendChild(planList);
-  container.appendChild(planSection);
-
-  applyIndexStyles(container);
-}
-
-function applyIndexStyles(container) {
-  const spans = container.querySelectorAll('.index-val');
-  spans.forEach((el) => {
-    const val = parseFloat(el.dataset.index);
-    if (val > 100) {
-      el.style.color = '#00ffae';
-      el.style.textShadow = '0 0 6px #00ffae';
-    } else {
-      el.style.color = 'red';
-      el.style.textShadow = '0 0 6px red';
-    }
-  });
+  root.innerHTML = html;
 }
 
 const stored = localStorage.getItem('audienceResult');
 if (stored) {
-  const data = JSON.parse(stored);
-  renderAudienceResults(data);
+  renderAudienceResults(JSON.parse(stored));
 } else {
-  // Fallback to sample data when no stored result exists
-  fetch('sample_result.json')
-    .then((r) => r.json())
-    .then((data) => {
-      renderAudienceResults(data);
-    });
+  fetch('sample_result.json').then(r => r.json()).then(data => renderAudienceResults(data));
 }


### PR DESCRIPTION
## Summary
- handle media lookup when keys don't exactly match segment names
- format spend values on the results page
- ensure full-screen results section styling
- update tests for new media lookup logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d4515a838832db4ca2adae8eda63e