### PR TITLE
Add search and budget enhancements

### DIFF
--- a/results.html
+++ b/results.html
@@ -26,10 +26,21 @@
   </style>
 </head>
 <body>
+  <section style="background: linear-gradient(to bottom, #000, #0a0a0a); padding: 40px 20px; text-align: center;">
+    <div style="width:100%; max-width:540px; margin:auto; display:flex; flex-direction:column; gap:16px;">
+      <input type="text" id="postcodeInput" placeholder="Enter postcode, ZIP or search term" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+      <input type="number" id="budgetInput" placeholder="Budget (£)" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+      <button id="submitButton" type="button" style="background:#00ffae; color:#000; font-weight:bold; font-size:1rem; padding:14px; border-radius:12px; border:none; transition:background 0.3s;">GET INSIGHTS</button>
+    </div>
+    <div id="resultContainer" class="hidden"></div>
+  </section>
+
   <section id="resultsSection" style="background: linear-gradient(to bottom, #000, #0a0a0a); min-height: 100vh; padding: 60px 20px;">
     <div id="resultsRoot" style="max-width: 1200px; margin: auto; display: flex; flex-direction: column; gap: 40px;"></div>
   </section>
 
   <script src="results.js"></script>
+  <script src="budget.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/results.js
+++ b/results.js
@@ -8,6 +8,7 @@ function renderAudienceResults(data) {
       <h2 style="font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; color: #00ffae;">${data.mosaic_group}</h2>
       <p style="color: #aaa; font-size: 1.2rem; max-width: 720px; margin: 12px auto 0;">${data.description}</p>
     </div>
+    ${typeof data.total_budget === 'number' ? `<div style="background:#111; border-radius:12px; padding:24px; box-shadow:0 0 16px rgba(0,255,174,0.3); text-align:center;"><p style="margin:0;color:#00ffae;font-weight:600;">Total Media Budget</p><p style="margin:0;font-size:1.4rem;">£${data.total_budget.toFixed(2)}</p></div>` : ''}
     <div style="background: #111; border-left: 4px solid #00ffae; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);">
       <h3 style="color: #00ffae; margin-bottom: 8px;">What is an Index?</h3>
       <p style="margin: 0; color: #ccc;">An index score compares this group’s likelihood of a behaviour or trait against the UK average (100). An index of 130 means this group is 30% more likely than average to exhibit that trait.</p>

--- a/sample_result.json
+++ b/sample_result.json
@@ -17,5 +17,6 @@
   "media_plan_allocation": [
     { "channel": "Paid Social", "index": 143, "budget": 6820 },
     { "channel": "Radio", "index": 84, "budget": 0 }
-  ]
+  ],
+  "total_budget": 6820
 }


### PR DESCRIPTION
## Summary
- add search UI to results page so users can start a new lookup without leaving
- fetch detailed Mosaic features and include in stored results
- show total media budget on the results page
- update sample result JSON with total budget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8fdbfca4832d892906727bc773ee