### PR TITLE
Add Mosaic group detail cards

### DIFF
--- a/main.js
+++ b/main.js
@@ -124,6 +124,9 @@ document.getElementById("submitButton").addEventListener("click", () => {
 
       const groupName = groupInfo.group_name || topSegments[0].type;
       let detailedFeatures = featureInfo.features || [];
+      let whoWeAre = [];
+      let responseChannels = [];
+      let householdTech = '';
       try {
         const detailFile = `${groupName.replace(/ /g, '_')}_Detailed.json`;
         const r = await fetch(detailFile);
@@ -131,6 +134,15 @@ document.getElementById("submitButton").addEventListener("click", () => {
           const detail = await r.json();
           if (Array.isArray(detail["Key Features"])) {
             detailedFeatures = detail["Key Features"];
+          }
+          if (detail["Who We Are"] && typeof detail["Who We Are"] === 'object') {
+            whoWeAre = Object.entries(detail["Who We Are"]).map(([label, value]) => ({ label, value }));
+          }
+          if (detail["Advert Response Channel Index"] && typeof detail["Advert Response Channel Index"] === 'object') {
+            responseChannels = Object.entries(detail["Advert Response Channel Index"]).map(([channel, index]) => ({ channel, index }));
+          }
+          if (typeof detail["Household Technology"] === 'string') {
+            householdTech = detail["Household Technology"];
           }
         }
       } catch (_) {
@@ -140,9 +152,11 @@ document.getElementById("submitButton").addEventListener("click", () => {
       const resultObj = {
         mosaic_group: `${groupName} (Group ${groupCode})`,
         description: groupInfo.description || '',
-        demographics: [],
+        demographics: whoWeAre,
         key_features: detailedFeatures,
         media_channels: mainMedia.map((m) => ({ label: m.channel, index: m.index })),
+        response_channels: responseChannels,
+        household_technology: householdTech,
         top_postcodes: [{ code: postcode, count: totalCount }],
         media_plan_allocation: plan,
         total_budget: budget,

--- a/results.js
+++ b/results.js
@@ -14,7 +14,7 @@ function renderAudienceResults(data) {
       <p style="margin: 0; color: #ccc;">An index score compares this group’s likelihood of a behaviour or trait against the UK average (100). An index of 130 means this group is 30% more likely than average to exhibit that trait.</p>
     </div>
     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 24px;">
-      ${data.demographics.map(d => `<div style="background: #111; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);"><p style="color: #00ffae; font-weight: 600; margin-bottom: 4px;">${d.label}</p><p>${d.value} <span style="color:#aaa">(Index: ${d.index})</span></p></div>`).join('')}
+      ${data.demographics.map(d => `<div style="background: #111; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);"><p style="color: #00ffae; font-weight: 600; margin-bottom: 4px;">${d.label}</p><p>${d.value}${d.index !== undefined ? ` <span style=\"color:#aaa\">(Index: ${d.index})</span>` : ''}</p></div>`).join('')}
     </div>
     <div style="background: #111; border-radius: 12px; padding: 24px; box-shadow: 0 0 16px rgba(0,255,174,0.3);">
       <h4 style="color: #00ffae; margin-bottom: 12px;">Key Features</h4>
@@ -22,6 +22,8 @@ function renderAudienceResults(data) {
         ${data.key_features.map(f => `<li>${f}</li>`).join('')}
       </ul>
     </div>
+    ${data.household_technology ? `<div style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);text-align:center;"><p style="margin:0;color:#ccc;">Household Technology Level</p><p style="margin:0;font-size:1.2rem;color:#00ffae;font-weight:600;">${data.household_technology}</p></div>` : ''}
+    ${Array.isArray(data.response_channels) && data.response_channels.length ? `<div><h3 style="font-size:1.5rem;font-weight:700;color:#00ffae;">Advert Response Channel Index</h3><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:24px;margin-top:20px;">${data.response_channels.map(r => { const high = r.index > 100; const color = high ? '#00ffae' : 'red'; const shadow = high ? '0 0 24px rgba(0,255,174,0.5)' : '0 0 24px rgba(255,0,0,0.5)'; return `<div style=\"background:#111;border-radius:12px;padding:20px;text-align:center;box-shadow:${shadow};\"><p style=\"margin:0;color:#ccc;\">${r.channel}</p><p style=\"color:${color};font-weight:bold;\">${r.index}</p></div>`; }).join('')}</div></div>` : ''}
     <div>
       <h3 style="font-size: 1.5rem; font-weight: 700; color: #00ffae;">Media Channel Effectiveness</h3>
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 24px; margin-top: 20px;">


### PR DESCRIPTION
## Summary
- expose additional Mosaic group data when preparing results
- show household technology and response channel indexes on results page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d92330988832d80bff447f4a1500c