### PR TITLE
Fix OpenAI module compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
 
 ## Usage
-1. Install Node.js if you have not already.
+1. Install Node.js (v18 or newer is recommended). If you must use an older version, install the `node-fetch` package so the OpenAI requests work.
 2. Run `npm start` from the project root to launch a small local server.
 3. Open `http://localhost:8000` in your browser.
 4. Enter a postcode or search term to view the Mosaic groups and weighted media budget.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,13 @@ const fs = require('fs');
 const path = require('path');
 const { loadCounts } = require('./groupCounts');
 
+// Ensure `fetch` is available for older Node versions
+let fetchFn = global.fetch;
+if (typeof fetchFn !== 'function') {
+  fetchFn = (...args) =>
+    import('node-fetch').then(({ default: fetch }) => fetch(...args));
+}
+
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 const port = process.env.PORT || 8000;
@@ -26,7 +33,7 @@ async function handleOpenAIRequest(req, res) {
       }).join('\n');
 
       const prompt = `${query}\n\nUse the following JSON data to answer:`;
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- patch README with note about Node.js versions
- make server fallback to `node-fetch` when `fetch` isn't available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ead6d188c832d87a13f39a41976e1