### PR TITLE
Improve OpenAI fallback and add results card

### DIFF
--- a/results.js
+++ b/results.js
@@ -64,9 +64,44 @@ function renderAudienceResults(data) {
         </div>
       </div>
     </div>
+    <div id="openAIInfoCard" style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);">
+      <p style="margin:0;color:#00ffae;font-weight:600;">Core-IQ™ Insight</p>
+      <div id="openAIContent" style="margin-top:10px;color:#ccc;">Loading details...</div>
+      <div style="margin-top:12px;display:flex;gap:8px;">
+        <input id="openAIQuestion" placeholder="Ask more about this group" style="flex:1;padding:8px;border-radius:8px;border:none;background:#222;color:#fff;" />
+        <button id="openAIAskBtn" style="background:#00ffae;color:#000;border:none;padding:8px 12px;border-radius:8px;font-weight:bold;">Ask</button>
+      </div>
+    </div>
   `;
 
   root.innerHTML = html;
+
+  const infoEl = document.getElementById('openAIContent');
+  fetch('/api/openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: `Tell me about Experian Mosaic ${data.mosaic_group}` })
+  })
+    .then(r => r.json())
+    .then(d => { infoEl.textContent = d.answer; })
+    .catch(() => { infoEl.textContent = 'Core-IQ service unavailable.'; });
+
+  document.getElementById('openAIAskBtn').addEventListener('click', () => {
+    const qInput = document.getElementById('openAIQuestion');
+    const question = qInput.value.trim();
+    if (!question) return;
+    qInput.value = '';
+    const append = txt => { const p = document.createElement('p'); p.style.margin = '4px 0'; p.textContent = txt; infoEl.appendChild(p); };
+    append('You: ' + question);
+    fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: `${question} (about Experian Mosaic ${data.mosaic_group})` })
+    })
+      .then(r => r.json())
+      .then(d => append('AI: ' + d.answer))
+      .catch(() => append('AI: error retrieving answer'));
+  });
 }
 
 const stored = localStorage.getItem('audienceResult');

--- a/server.js
+++ b/server.js
@@ -17,8 +17,8 @@ const GROUP_COUNTS = loadCounts();
 
 async function handleOpenAIRequest(req, res) {
   if (!OPENAI_API_KEY) {
-    res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end('OpenAI API key not configured');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ answer: 'OpenAI service unavailable. Please configure OPENAI_API_KEY.' }));
     return;
   }
   let body = '';
@@ -53,8 +53,8 @@ async function handleOpenAIRequest(req, res) {
       res.end(JSON.stringify({ answer }));
     } catch (err) {
       console.error(err);
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('OpenAI request failed');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ answer: 'OpenAI request failed. Please check your network connection.' }));
     }
   });
 }


### PR DESCRIPTION
## Summary
- implement graceful fallback in `server.js` when OpenAI is unavailable
- display an AI insight card on the results page
- allow visitors to ask follow-up questions about the Mosaic group from the results page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec5aedc38832da3ce0308c1086274