### PR TITLE
Improve OpenAI query handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,22 @@ This is a lightweight demo that displays audience insights by UK postcode or US 
 To enable natural language queries processed via OpenAI, set an environment variable `OPENAI_API_KEY` before starting the server:
 
 ```bash
-export OPENAI_API_KEY=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
+export OPENAI_API_KEY=<your-api-key>
 npm start
 ```
 
-When a search term does not match local data, the server will forward the query and a snippet of the JSON files to OpenAI and display the response.
+When a search term does not match local data, the server forwards the query
+with excerpts from up to three JSON files selected using the query text and
+Mosaic group names. Postcode lookups support partial codes like "EC1", and
+Mosaic group codes (like "A" for City Prosperity) also map
+to their detailed JSON automatically. This keeps requests focused on the most
+relevant data and helps avoid conflicting information in answers. The server
+uses the `gpt-4o` (ChatGPT 4.0) model to generate responses.
+
+The results page includes a **Core-IQ™ Insight** card that shows the OpenAI
+response for the most relevant Mosaic group. You can ask follow‑up questions in
+the card’s input field. If the OpenAI request fails (for example, if the API
+key is missing), a helpful error message appears instead.
 
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
 

--- a/results.js
+++ b/results.js
@@ -64,9 +64,44 @@ function renderAudienceResults(data) {
         </div>
       </div>
     </div>
+    <div id="openAIInfoCard" style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);">
+      <p style="margin:0;color:#00ffae;font-weight:600;">Core-IQ™ Insight</p>
+      <div id="openAIContent" style="margin-top:10px;color:#ccc;">Loading details...</div>
+      <div style="margin-top:12px;display:flex;gap:8px;">
+        <input id="openAIQuestion" placeholder="Ask more about this group" style="flex:1;padding:8px;border-radius:8px;border:none;background:#222;color:#fff;" />
+        <button id="openAIAskBtn" style="background:#00ffae;color:#000;border:none;padding:8px 12px;border-radius:8px;font-weight:bold;">Ask</button>
+      </div>
+    </div>
   `;
 
   root.innerHTML = html;
+
+  const infoEl = document.getElementById('openAIContent');
+  fetch('/api/openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: `Tell me about Experian Mosaic ${data.mosaic_group}` })
+  })
+    .then(r => r.json())
+    .then(d => { infoEl.textContent = d.answer || d.error || 'Core-IQ service unavailable.'; })
+    .catch(() => { infoEl.textContent = 'Core-IQ service unavailable.'; });
+
+  document.getElementById('openAIAskBtn').addEventListener('click', () => {
+    const qInput = document.getElementById('openAIQuestion');
+    const question = qInput.value.trim();
+    if (!question) return;
+    qInput.value = '';
+    const append = txt => { const p = document.createElement('p'); p.style.margin = '4px 0'; p.textContent = txt; infoEl.appendChild(p); };
+    append('You: ' + question);
+    fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: `${question} (about Experian Mosaic ${data.mosaic_group})` })
+    })
+      .then(r => r.json())
+      .then(d => append('AI: ' + (d.answer || d.error || 'error'))) 
+      .catch(() => append('AI: error retrieving answer'));
+  });
 }
 
 const stored = localStorage.getItem('audienceResult');

--- a/server.js
+++ b/server.js
@@ -15,18 +15,106 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const port = process.env.PORT || 8000;
 const GROUP_COUNTS = loadCounts();
 
+function loadGroupMap() {
+  const groupMap = {};
+  const pc = path.join(__dirname, 'primary_content.json');
+  if (!fs.existsSync(pc)) return groupMap;
+  try {
+    const text = fs.readFileSync(pc, 'utf8').replace(/NaN/g, 'null');
+    const groups = JSON.parse(text);
+    groups.forEach(g => {
+      const nameKey = (g.group_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+      const codeKey = String(g.group_code || '').toLowerCase();
+      const fname = g.group_name.replace(/\s+/g, '_') + '_Detailed.json';
+      if (fs.existsSync(path.join(__dirname, fname))) {
+        groupMap[nameKey] = fname;
+        if (codeKey) {
+          groupMap[codeKey] = fname;
+          groupMap[`group${codeKey}`] = fname;
+        }
+      }
+    });
+  } catch (_) {
+    return groupMap;
+  }
+  return groupMap;
+}
+
+const GROUP_MAP = loadGroupMap();
+
+// lookup helpers for location-based JSON files
+function loadLookupKeys(fname) {
+  try {
+    const full = path.join(__dirname, fname);
+    if (fs.existsSync(full)) {
+      const obj = JSON.parse(fs.readFileSync(full, 'utf8').replace(/NaN/g, 'null'));
+      return Object.keys(obj).map(k => k.toLowerCase());
+    }
+  } catch (_) {}
+  return [];
+}
+
+const CITY_KEYS = loadLookupKeys('city_to_mosaic.json');
+const LA_KEYS = loadLookupKeys('local_authority_to_mosaic.json');
+const REGION_KEYS = loadLookupKeys('region_to_mosaic.json');
+
+function selectRelevantFiles(query) {
+  const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.json'));
+  const text = (query || '').toLowerCase();
+  const clean = text.replace(/[^a-z0-9\s]/g, '');
+
+  // direct match to a known Mosaic group
+  for (const [key, fname] of Object.entries(GROUP_MAP)) {
+    if (clean.includes(key)) {
+      return [fname];
+    }
+  }
+
+  const matches = new Set();
+
+  // postcode (full or partial like EC1)
+  const postcodeRE = /\b[a-z]{1,2}\d[a-z0-9]?\d?[a-z]{0,2}\b/i;
+  if (postcodeRE.test(query)) {
+    matches.add('postcode_to_mosaic.json');
+  }
+
+  // check location names
+  const locWords = clean.split(/\s+/);
+  locWords.forEach(w => {
+    if (CITY_KEYS.includes(w)) matches.add('city_to_mosaic.json');
+    if (LA_KEYS.includes(w)) matches.add('local_authority_to_mosaic.json');
+    if (REGION_KEYS.includes(w)) matches.add('region_to_mosaic.json');
+  });
+
+  // simple keyword mapping
+  if (clean.includes('coffee')) matches.add('primary_content.json');
+  if (clean.includes('feline') || clean.includes('cat')) matches.add('help.json');
+
+  // fallback search using file names
+  locWords.forEach(k => {
+    if (GROUP_MAP[k]) matches.add(GROUP_MAP[k]);
+    files.forEach(f => {
+      if (f.toLowerCase().includes(k)) matches.add(f);
+    });
+  });
+
+  if (matches.size === 0) matches.add('primary_content.json');
+
+  return Array.from(matches).slice(0, 5);
+}
+
 async function handleOpenAIRequest(req, res) {
   if (!OPENAI_API_KEY) {
-    res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end('OpenAI API key not configured');
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'OPENAI_API_KEY not set' }));
     return;
   }
   let body = '';
   req.on('data', chunk => body += chunk);
   req.on('end', async () => {
     try {
-      const { query } = JSON.parse(body || '{}');
-      const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.json'));
+      const { query = '' } = JSON.parse(body || '{}');
+      const files = selectRelevantFiles(query);
       const dataSnippets = files.map(f => {
         const content = fs.readFileSync(path.join(__dirname, f), 'utf8');
         return `File: ${f}\n${content.substring(0, 1000)}`;
@@ -40,7 +128,7 @@ async function handleOpenAIRequest(req, res) {
           'Authorization': `Bearer ${OPENAI_API_KEY}`
         },
         body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
+          model: 'gpt-4o',
           messages: [
             { role: 'system', content: 'You are a helpful assistant that answers questions about the provided JSON.' },
             { role: 'user', content: `${prompt}\n${dataSnippets}` }
@@ -53,8 +141,8 @@ async function handleOpenAIRequest(req, res) {
       res.end(JSON.stringify({ answer }));
     } catch (err) {
       console.error(err);
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('OpenAI request failed');
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'OpenAI request failed' }));
     }
   });
 }


### PR DESCRIPTION
## Summary
- note the new Core-IQ Insight card in the README
- extend server `selectRelevantFiles` to check postcodes, city and local authority names, and some keywords
- fall back to up to five JSON files for richer responses
- better postcode matching for queries like "EC1"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ec5aedc38832da3ce0308c1086274