### PR TITLE
Return OpenAI errors as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,22 @@ This is a lightweight demo that displays audience insights by UK postcode or US 
 To enable natural language queries processed via OpenAI, set an environment variable `OPENAI_API_KEY` before starting the server:
 
 ```bash
-export OPENAI_API_KEY=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
+export OPENAI_API_KEY=<your-api-key>
 npm start
 ```
 
-When a search term does not match local data, the server will forward the query and a snippet of the JSON files to OpenAI and display the response.
+When a search term does not match local data, the server forwards the query
+with snippets from **up to five** relevant JSON files. Postcode lookups support
+partial codes like "EC1", and Mosaic group codes (such as "A" for City
+Prosperity) automatically map to their detailed JSON. The server uses the
+`gpt-4o` (ChatGPT 4.0) model to generate responses.
+
+The results page includes a **Core-IQ™ Insight** card that shows the OpenAI
+response for the most relevant Mosaic group. You can ask follow‑up questions in
+the card’s input field. If the OpenAI request fails (for example, if the API
+key is missing or the network is down), a helpful error message appears instead.
+Server-side responses now check for OpenAI errors and return that message in an
+`error` field so the page can surface the issue.
 
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
 

--- a/results.js
+++ b/results.js
@@ -64,9 +64,44 @@ function renderAudienceResults(data) {
         </div>
       </div>
     </div>
+    <div id="openAIInfoCard" style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);">
+      <p style="margin:0;color:#00ffae;font-weight:600;">Core-IQ™ Insight</p>
+      <div id="openAIContent" style="margin-top:10px;color:#ccc;">Loading details...</div>
+      <div style="margin-top:12px;display:flex;gap:8px;">
+        <input id="openAIQuestion" placeholder="Ask more about this group" style="flex:1;padding:8px;border-radius:8px;border:none;background:#222;color:#fff;" />
+        <button id="openAIAskBtn" style="background:#00ffae;color:#000;border:none;padding:8px 12px;border-radius:8px;font-weight:bold;">Ask</button>
+      </div>
+    </div>
   `;
 
   root.innerHTML = html;
+
+  const infoEl = document.getElementById('openAIContent');
+  fetch('/api/openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: `Tell me about Experian Mosaic ${data.mosaic_group}` })
+  })
+    .then(r => r.json())
+    .then(d => { infoEl.textContent = d.answer || d.error || 'Core-IQ service unavailable.'; })
+    .catch(() => { infoEl.textContent = 'Core-IQ service unavailable.'; });
+
+  document.getElementById('openAIAskBtn').addEventListener('click', () => {
+    const qInput = document.getElementById('openAIQuestion');
+    const question = qInput.value.trim();
+    if (!question) return;
+    qInput.value = '';
+    const append = txt => { const p = document.createElement('p'); p.style.margin = '4px 0'; p.textContent = txt; infoEl.appendChild(p); };
+    append('You: ' + question);
+    fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: `${question} (about Experian Mosaic ${data.mosaic_group})` })
+    })
+      .then(r => r.json())
+      .then(d => append('AI: ' + (d.answer || d.error || 'error'))) 
+      .catch(() => append('AI: error retrieving answer'));
+  });
 }
 
 const stored = localStorage.getItem('audienceResult');

--- a/server.js
+++ b/server.js
@@ -15,18 +15,66 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const port = process.env.PORT || 8000;
 const GROUP_COUNTS = loadCounts();
 
+const GROUP_FILE_MAP = {
+  A: 'City_Prosperity_Detailed.json',
+  B: 'Prestige_Positions_Detailed.json',
+  C: 'Country_Living_Detailed.json',
+  D: 'Rural_Reality_Detailed.json',
+  E: 'Senior_Security_Detailed.json',
+  F: 'Suburban_Stability_Detailed.json',
+  G: 'Domestic_Success_Detailed.json',
+  H: 'Aspiring_Homemakers_Detailed.json',
+  I: 'Family_Basics_Detailed.json',
+  J: 'Transient_Renters_Detailed.json',
+  K: 'Municipal_Tenants_Detailed.json',
+  L: 'Vintage_Value_Detailed.json',
+  M: null, // Modest Traditions file not present
+  N: 'Urban_Cohesion_Detailed.json',
+  O: 'Rental_Hubs_Detailed.json'
+};
+
+function selectRelevantFiles(query) {
+  const lower = String(query || '').toLowerCase();
+  const files = new Set(['primary_content.json']);
+
+  const codeMatch = lower.match(/\b([a-o])\b/i);
+  if (codeMatch) {
+    const f = GROUP_FILE_MAP[codeMatch[1].toUpperCase()];
+    if (f) files.add(f);
+  }
+
+  for (const [code, file] of Object.entries(GROUP_FILE_MAP)) {
+    if (!file) continue;
+    const name = file.replace(/_Detailed\.json$/, '').replace(/_/g, ' ').toLowerCase();
+    if (lower.includes(name)) {
+      files.add(file);
+      break;
+    }
+  }
+
+  if (/[a-z]{1,2}\d[a-z0-9]?\d?[a-z]{0,2}/i.test(query)) {
+    files.add('postcode_to_mosaic.json');
+  }
+
+  if (/(city|cities)/i.test(query)) files.add('city_to_mosaic.json');
+  if (/region/i.test(query)) files.add('region_to_mosaic.json');
+  if (/authority|council/i.test(query)) files.add('local_authority_to_mosaic.json');
+
+  return Array.from(files).slice(0, 5);
+}
+
 async function handleOpenAIRequest(req, res) {
   if (!OPENAI_API_KEY) {
-    res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end('OpenAI API key not configured');
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'OPENAI_API_KEY not set' }));
     return;
   }
   let body = '';
   req.on('data', chunk => body += chunk);
   req.on('end', async () => {
     try {
-      const { query } = JSON.parse(body || '{}');
-      const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.json'));
+      const { query = '' } = JSON.parse(body || '{}');
+      const files = selectRelevantFiles(query);
       const dataSnippets = files.map(f => {
         const content = fs.readFileSync(path.join(__dirname, f), 'utf8');
         return `File: ${f}\n${content.substring(0, 1000)}`;
@@ -40,21 +88,25 @@ async function handleOpenAIRequest(req, res) {
           'Authorization': `Bearer ${OPENAI_API_KEY}`
         },
         body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
+          model: 'gpt-4o',
           messages: [
             { role: 'system', content: 'You are a helpful assistant that answers questions about the provided JSON.' },
             { role: 'user', content: `${prompt}\n${dataSnippets}` }
           ]
         })
       });
+      if (!response.ok) {
+        const error = await response.text();
+        throw new Error(error);
+      }
       const result = await response.json();
       const answer = result.choices?.[0]?.message?.content || 'No answer';
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ answer }));
     } catch (err) {
       console.error(err);
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('OpenAI request failed');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message || 'OpenAI request failed' }));
     }
   });
 }


### PR DESCRIPTION
## Summary
- clarify in README that server puts error messages in the `error` field
- return the actual error message from the OpenAI request

## Testing
- `npm test`
- `curl -X POST http://localhost:8000/api/openai -d '{"query":"felines aged 20 in cardiff, coffee"}' -H 'Content-Type: application/json'`

------
https://chatgpt.com/codex/tasks/task_e_685ec5aedc38832da3ce0308c1086274