### PR TITLE
Return OpenAI errors as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,32 @@ This is a lightweight demo that displays audience insights by UK postcode or US 
 To enable natural language queries processed via OpenAI, set an environment variable `OPENAI_API_KEY` before starting the server:
 
 ```bash
-export OPENAI_API_KEY=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
+export OPENAI_API_KEY=<your-api-key>
 npm start
 ```
 
-When a search term does not match local data, the server will forward the query and a snippet of the JSON files to OpenAI and display the response.
+When a search term does not match local data, the server forwards the query
+with snippets from **every** JSON file in the project so OpenAI has the full
+dataset. Postcode lookups support partial codes like "EC1", and Mosaic group
+codes (such as "A" for City Prosperity) automatically map to their detailed
+JSON. The server uses the `gpt-4o` (ChatGPT 4.0) model to generate responses.
+
+You can test the endpoint directly with `curl`:
+
+```bash
+curl -X POST http://localhost:8000/api/openai \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"Females in Cardiff"}'
+```
+
+The results page includes a **Core-IQ™ Insight** card that shows the OpenAI
+response for the most relevant Mosaic group. You can ask follow‑up questions in
+the card’s input field. If the OpenAI request fails (for example, if the API
+key is missing or the network is down), a helpful error message appears instead.
+Server-side responses now check for OpenAI errors and return that message in an
+`error` field so the page can surface the issue.
+If you start the server without setting `OPENAI_API_KEY`, the response will
+contain `{ "error": "OPENAI_API_KEY not set" }` to make troubleshooting clear.
 
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
 

--- a/main.js
+++ b/main.js
@@ -337,7 +337,8 @@ function queryOpenAI(query, container) {
   })
     .then(r => r.json())
     .then(data => {
-      container.innerHTML = `<div class="insight-card">${data.answer}</div>`;
+      localStorage.setItem('openAIResult', JSON.stringify({ query, answer: data.answer || data.error || 'No answer' }));
+      window.location.href = 'results.html';
     })
     .catch(err => {
       console.error('OpenAI request failed', err);

--- a/results.js
+++ b/results.js
@@ -64,14 +64,88 @@ function renderAudienceResults(data) {
         </div>
       </div>
     </div>
+    <div id="openAIInfoCard" style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);">
+      <p style="margin:0;color:#00ffae;font-weight:600;">Core-IQ™ Insight</p>
+      <div id="openAIContent" style="margin-top:10px;color:#ccc;">Loading details...</div>
+      <div style="margin-top:12px;display:flex;gap:8px;">
+        <input id="openAIQuestion" placeholder="Ask more about this group" style="flex:1;padding:8px;border-radius:8px;border:none;background:#222;color:#fff;" />
+        <button id="openAIAskBtn" style="background:#00ffae;color:#000;border:none;padding:8px 12px;border-radius:8px;font-weight:bold;">Ask</button>
+      </div>
+    </div>
   `;
 
   root.innerHTML = html;
+
+  const infoEl = document.getElementById('openAIContent');
+  fetch('/api/openai', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: `Tell me about Experian Mosaic ${data.mosaic_group}` })
+  })
+    .then(r => r.json())
+    // Fallback logic from gp78hu-codex/fix-search-functionality-and-add-core-iq-card
+    .then(d => { infoEl.textContent = d.answer || d.error || 'Core-IQ service unavailable.'; })
+    .catch(() => { infoEl.textContent = 'Core-IQ service unavailable.'; });
+
+  document.getElementById('openAIAskBtn').addEventListener('click', () => {
+    const qInput = document.getElementById('openAIQuestion');
+    const question = qInput.value.trim();
+    if (!question) return;
+    qInput.value = '';
+    const append = txt => { const p = document.createElement('p'); p.style.margin = '4px 0'; p.textContent = txt; infoEl.appendChild(p); };
+    append('You: ' + question);
+    fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: `${question} (about Experian Mosaic ${data.mosaic_group})` })
+    })
+      .then(r => r.json())
+      .then(d => append('AI: ' + (d.answer || d.error || 'error'))) 
+      .catch(() => append('AI: error retrieving answer'));
+  });
+}
+
+function renderOpenAIResult(data) {
+  const root = document.getElementById('resultsRoot');
+  if (!root) return;
+  const html = `
+    <div id="openAIInfoCard" style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);">
+      <p style="margin:0;color:#00ffae;font-weight:600;">Core-IQ™ Insight</p>
+      <div id="openAIContent" style="margin-top:10px;color:#ccc;">${data.answer}</div>
+      <div style="margin-top:12px;display:flex;gap:8px;">
+        <input id="openAIQuestion" placeholder="Ask a follow-up question" style="flex:1;padding:8px;border-radius:8px;border:none;background:#222;color:#fff;" />
+        <button id="openAIAskBtn" style="background:#00ffae;color:#000;border:none;padding:8px 12px;border-radius:8px;font-weight:bold;">Ask</button>
+      </div>
+    </div>`;
+  root.innerHTML = html;
+
+  const infoEl = document.getElementById('openAIContent');
+  document.getElementById('openAIAskBtn').addEventListener('click', () => {
+    const qInput = document.getElementById('openAIQuestion');
+    const question = qInput.value.trim();
+    if (!question) return;
+    qInput.value = '';
+    const append = txt => { const p = document.createElement('p'); p.style.margin = '4px 0'; p.textContent = txt; infoEl.appendChild(p); };
+    append('You: ' + question);
+    fetch('/api/openai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: `${question} (context: ${data.query})` })
+    })
+      .then(r => r.json())
+      .then(d => append('AI: ' + (d.answer || d.error || 'error')))
+      .catch(() => append('AI: error retrieving answer'));
+  });
 }
 
 const stored = localStorage.getItem('audienceResult');
+const openStored = localStorage.getItem('openAIResult');
 if (stored) {
   renderAudienceResults(JSON.parse(stored));
+  localStorage.removeItem('openAIResult');
+} else if (openStored) {
+  renderOpenAIResult(JSON.parse(openStored));
+  localStorage.removeItem('openAIResult');
 } else {
   fetch('sample_result.json').then(r => r.json()).then(data => renderAudienceResults(data));
 }

--- a/server.js
+++ b/server.js
@@ -15,17 +15,18 @@ const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const port = process.env.PORT || 8000;
 const GROUP_COUNTS = loadCounts();
 
+
 async function handleOpenAIRequest(req, res) {
   if (!OPENAI_API_KEY) {
-    res.writeHead(500, { 'Content-Type': 'text/plain' });
-    res.end('OpenAI API key not configured');
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'OPENAI_API_KEY not set' }));
     return;
   }
   let body = '';
   req.on('data', chunk => body += chunk);
   req.on('end', async () => {
     try {
-      const { query } = JSON.parse(body || '{}');
+      const { query = '' } = JSON.parse(body || '{}');
       const files = fs.readdirSync(__dirname).filter(f => f.endsWith('.json'));
       const dataSnippets = files.map(f => {
         const content = fs.readFileSync(path.join(__dirname, f), 'utf8');
@@ -40,21 +41,25 @@ async function handleOpenAIRequest(req, res) {
           'Authorization': `Bearer ${OPENAI_API_KEY}`
         },
         body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
+          model: 'gpt-4o',
           messages: [
             { role: 'system', content: 'You are a helpful assistant that answers questions about the provided JSON.' },
             { role: 'user', content: `${prompt}\n${dataSnippets}` }
           ]
         })
       });
+      if (!response.ok) {
+        const error = await response.text();
+        throw new Error(error);
+      }
       const result = await response.json();
       const answer = result.choices?.[0]?.message?.content || 'No answer';
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ answer }));
     } catch (err) {
       console.error(err);
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('OpenAI request failed');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.message || 'OpenAI request failed' }));
     }
   });
 }


### PR DESCRIPTION
## Summary
- clarify in README that server puts error messages in the `error` field
- return the actual error message from the OpenAI request
- store OpenAI answers in `localStorage` and display them on the results page
- clarify that the API returns `{ "error": "OPENAI_API_KEY not set" }` if the key is missing
- fix merge conflict markers in `results.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ec5aedc38832da3ce0308c1086274