### PR TITLE
Fallback stubbed OpenAI responses offline

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Server-side responses now check for OpenAI errors and return that message in an
 If you start the server without setting `OPENAI_API_KEY`, the response will
 contain `{ "error": "OPENAI_API_KEY not set" }` to make troubleshooting clear.
 
+If the UI shows **"Core-IQ service unavailable"**, it usually means the page
+couldn't reach the local Node server or the server couldn't contact OpenAI. Make
+sure `npm start` is running and that your `.env` file contains a valid
+`OPENAI_API_KEY`. When running without network access, execute `./setup.sh` first
+to install stub modules so the demo can still respond. If the key is missing or
+the OpenAI request fails, the server now falls back to a stubbed reply so search
+pages keep working.
+
+You can also test the SDK locally with `node assistant.js` (uses a stub without
+internet).
+
 The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
 
 Animations rely on simple CSS transitions, so no external libraries such as AOS are required.

--- a/assistant.js
+++ b/assistant.js
@@ -1,0 +1,47 @@
+let dotenv;
+try {
+  dotenv = require('dotenv');
+} catch (_) {
+  dotenv = require('./stubs/dotenv');
+}
+dotenv.config();
+
+let OpenAI;
+try {
+  ({ OpenAI } = require('openai'));
+} catch (_) {
+  ({ OpenAI } = require('./stubs/openai'));
+}
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+const assistantId = 'asst_abc123xyz456'; // replace with your real ID
+
+async function runAssistant() {
+  const thread = await openai.beta.threads.create();
+
+  await openai.beta.threads.messages.create(thread.id, {
+    role: 'user',
+    content: 'Explain how recursion works in JavaScript'
+  });
+
+  const run = await openai.beta.threads.runs.create(thread.id, {
+    assistant_id: assistantId
+  });
+
+  // Wait for completion
+  let runStatus;
+  do {
+    runStatus = await openai.beta.threads.runs.retrieve(thread.id, run.id);
+    await new Promise(r => setTimeout(r, 1000));
+  } while (runStatus.status !== 'completed');
+
+  const messages = await openai.beta.threads.messages.list(thread.id);
+  const last = messages.data.find(m => m.role === 'assistant');
+
+  console.log('\u{1F4AC} Assistant says:', last.content[0].text.value);
+}
+
+runAssistant();

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 // main.js
 
-document.getElementById("submitButton").addEventListener("click", () => {
+async function runSearch() {
   // start a fresh search and clear any stored result
   localStorage.removeItem('audienceResult');
   const rawInput = document.getElementById("targetAreaInput").value;
@@ -191,6 +191,17 @@ document.getElementById("submitButton").addEventListener("click", () => {
       resultContainer.classList.remove("hidden");
       resultContainer.innerHTML = `<p>There was an error loading insights.</p>`;
     });
+}
+
+document.getElementById("submitButton").addEventListener("click", runSearch);
+
+["targetAreaInput", "budgetInput"].forEach(id => {
+  const el = document.getElementById(id);
+  el.addEventListener("keydown", e => {
+    if (e.key === "Enter") {
+      runSearch();
+    }
+  });
 });
 
 function searchVariable(query, container) {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "openai": "^4.0.0",
+    "dotenv": "^16.0.0"
+  }
 }

--- a/results.js
+++ b/results.js
@@ -93,8 +93,13 @@ function renderAudienceResults(data) {
     body: JSON.stringify({ query: `Tell me about Experian Mosaic ${data.mosaic_group}` })
   })
     .then(r => r.json())
-    .then(d => { infoEl.innerHTML = escapeHTML(d.answer || d.error || 'Core-IQ service unavailable.'); })
-    .catch(() => { infoEl.textContent = 'Core-IQ service unavailable.'; });
+    .then(d => {
+      infoEl.innerHTML = escapeHTML(d.answer || d.error || 'Core-IQ service unavailable.');
+    })
+    .catch(err => {
+      console.error('OpenAI fetch failed:', err);
+      infoEl.textContent = 'Core-IQ service unavailable. Is the server running and OPENAI_API_KEY set?';
+    });
 
   document.getElementById('openAIAskBtn').addEventListener('click', () => {
     const qInput = document.getElementById('openAIQuestion');
@@ -115,7 +120,10 @@ function renderAudienceResults(data) {
     })
       .then(r => r.json())
       .then(d => append('AI: ' + (d.answer || d.error || 'error')))
-      .catch(() => append('AI: error retrieving answer'));
+      .catch(err => {
+        console.error('OpenAI follow-up failed:', err);
+        append('AI: error retrieving answer');
+      });
   });
 }
 
@@ -155,7 +163,10 @@ function renderOpenAIResult(data) {
     })
       .then(r => r.json())
       .then(d => append('AI: ' + (d.answer || d.error || 'error')))
-      .catch(() => append('AI: error retrieving answer'));
+      .catch(err => {
+        console.error('OpenAI follow-up failed:', err);
+        append('AI: error retrieving answer');
+      });
   });
 }
 

--- a/server.js
+++ b/server.js
@@ -27,54 +27,57 @@ const JSON_SNIPPETS = loadJsonSnippets();
 const JSON_SNIPPET_STRING = JSON_SNIPPETS.join('\n');
 
 
-async function handleOpenAIRequest(req, res) {
+async function fetchOpenAIAnswer(query) {
   if (!OPENAI_API_KEY) {
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({
-      error: 'OpenAI service unavailable. Please configure OPENAI_API_KEY.'
-    }));
-    return;
+    return {
+      answer: 'Stubbed response from OpenAI. Set OPENAI_API_KEY for live results.'
+    };
   }
+  try {
+    const prompt = `${query}\n\nUse the following JSON data to answer:`;
+    const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a helpful assistant that answers questions about the provided JSON.'
+          },
+          { role: 'user', content: `${prompt}\n${JSON_SNIPPET_STRING}` }
+        ]
+      })
+    });
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(error);
+    }
+    const result = await response.json();
+    const answer = result.choices?.[0]?.message?.content || 'No answer';
+    return { answer };
+  } catch (err) {
+    console.error('OpenAI fetch failed:', err);
+    return { answer: 'Stubbed response from OpenAI (network error).' };
+  }
+}
+
+async function handleOpenAIRequest(req, res) {
   let body = '';
   req.on('data', chunk => (body += chunk));
   req.on('end', async () => {
     try {
       const { query = '' } = JSON.parse(body || '{}');
-
-      const prompt = `${query}\n\nUse the following JSON data to answer:`;
-      const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${OPENAI_API_KEY}`
-        },
-        body: JSON.stringify({
-          model: 'gpt-4o',
-          messages: [
-            {
-              role: 'system',
-              content: 'You are a helpful assistant that answers questions about the provided JSON.'
-            },
-            { role: 'user', content: `${prompt}\n${JSON_SNIPPET_STRING}` }
-          ]
-        })
-      });
-      if (!response.ok) {
-        const error = await response.text();
-        throw new Error(error);
-      }
-      const result = await response.json();
-      const answer = result.choices?.[0]?.message?.content || 'No answer';
+      const data = await fetchOpenAIAnswer(query);
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ answer }));
+      res.end(JSON.stringify(data));
     } catch (err) {
-      console.error(err);
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          error: err.message || 'OpenAI request failed. Please check your network connection.'
-        })
-      );
+      console.error('Failed to process OpenAI request:', err);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'OpenAI request failed' }));
     }
   });
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Install project dependencies. If npm install fails (e.g. no network),
+# fall back to local stub modules.
+set -e
+
+if npm install; then
+  echo "npm install succeeded"
+else
+  echo "npm install failed; using local stubs"
+  mkdir -p node_modules
+  cp -r stubs/* node_modules/
+fi

--- a/stubs/dotenv/index.js
+++ b/stubs/dotenv/index.js
@@ -1,0 +1,4 @@
+function config() {
+  return process.env;
+}
+module.exports = { config };

--- a/stubs/dotenv/package.json
+++ b/stubs/dotenv/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dotenv",
+  "version": "16.0.0",
+  "main": "index.js"
+}

--- a/stubs/openai/index.js
+++ b/stubs/openai/index.js
@@ -1,0 +1,27 @@
+class OpenAI {
+  constructor(opts = {}) {
+    this.apiKey = opts.apiKey;
+    this.beta = {
+      threads: {
+        create: async () => ({ id: 'thread-123' }),
+        messages: {
+          create: async (threadId, msg) => ({ id: 'msg-123', threadId, ...msg }),
+          list: async threadId => ({
+            data: [
+              {
+                role: 'assistant',
+                content: [{ text: { value: 'Stubbed response from OpenAI.' } }]
+              }
+            ]
+          })
+        },
+        runs: {
+          create: async (threadId, opts) => ({ id: 'run-123', threadId, ...opts }),
+          retrieve: async (threadId, runId) => ({ id: runId, status: 'completed' })
+        }
+      }
+    };
+  }
+}
+
+module.exports = { OpenAI };

--- a/stubs/openai/package.json
+++ b/stubs/openai/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "openai",
+  "version": "4.0.0",
+  "main": "index.js"
+}


### PR DESCRIPTION
## Summary
- use stub modules automatically in `assistant.js`
- return a stub OpenAI answer from the server when the real request fails
- clarify offline behavior in README

## Testing
- `npm test`
- `./setup.sh` *(fails to download packages, stubs copied)*
- `node assistant.js`


------
https://chatgpt.com/codex/tasks/task_e_686043bef054832db699748467456d5d