### PR TITLE
Add mapping of postcode prefixes to cities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a lightweight demo that displays audience insights by UK postcode or US 
 1. Install Node.js (v18 or newer is recommended). If you must use an older version, install the `node-fetch` package so the OpenAI requests work.
 2. Run `npm start` from the project root to launch a small local server.
 3. Open `http://localhost:8000` in your browser.
-4. Enter a postcode or search term to view the Mosaic groups and weighted media budget.
+4. Enter a postcode, city, or region to view the Mosaic groups and weighted media budget.
 
 ### OpenAI integration
 To enable natural language queries processed via OpenAI, set environment variables `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` before starting the server:

--- a/README.md
+++ b/README.md
@@ -1,86 +1,71 @@
-diff --git a/README.md b/README.md
-index a15fff9d98d7e03d90c513bad9b3a8a7a4d1f5cf..40af665eeec2818debf8aafd62c4ead298d55e97 100644
---- a/README.md
-+++ b/README.md
-@@ -1,71 +1,78 @@
- # CORE-IQ Demo
- 
- This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
- 
- ## Usage
- 1. Install Node.js (v18 or newer is recommended). If you must use an older version, install the `node-fetch` package so the OpenAI requests work.
- 2. Run `npm start` from the project root to launch a small local server.
-+   The server listens on port `8000` by default. Set the `PORT` environment
-+   variable if you need to use a different port.
- 3. Open `http://localhost:8000` in your browser.
- 4. Enter a postcode or search term to view the Mosaic groups and weighted media budget.
- 
- ### OpenAI integration
- To enable natural language queries processed via OpenAI, set environment variables `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` before starting the server:
- 
- ```bash
- export OPENAI_API_KEY=<your-api-key>
- export OPENAI_ASSISTANT_ID=<your-assistant-id>
- npm start
- ```
- 
- When a search term does not match local data, the server forwards the query to
- your configured OpenAI Assistant. Postcode lookups support partial codes like
- "EC1", and Mosaic group codes (such as "A" for City Prosperity) automatically
- map to their detailed JSON. The assistant handles these questions using the
- data uploaded to it.
- 
- You can test the endpoint directly with `curl`:
- 
- ```bash
- curl -X POST http://localhost:8000/api/openai \
-   -H 'Content-Type: application/json' \
-   -d '{"query":"Females in Cardiff"}'
- ```
- 
- The results page includes a **Core-IQ™ Insight** card that shows the OpenAI
- response for the most relevant Mosaic group. You can ask follow‑up questions in
- the card’s input field or use the **Ask Core-IQ** box on the home page to query
- the assistant directly. If the OpenAI request fails (for example, if the API
- key is missing or the network is down), a helpful error message appears instead.
- Server-side responses now check for OpenAI errors and return that message in an
- `error` field so the page can surface the issue.
- If you start the server without the required environment variables, the response
- will contain `{ "error": "Core-IQ service unavailable" }` to make troubleshooting
- clear.
- 
- If the UI shows **"Core-IQ service unavailable"**, it usually means the page
- couldn't reach the local Node server or the server couldn't contact OpenAI. Make
- sure `npm start` is running and that your `.env` file contains valid
- `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` values. When running without network
- access, execute `./setup.sh` first
- to install stub modules so the demo can still respond.
- 
- ### Python assistant script
- If you prefer using Python, the `assistant_python.py` utility demonstrates
--how to call an OpenAI Assistant. Install the requirement with:
-+how to call an OpenAI Assistant.
-+
-+If network access is available, install the real client with:
- 
- ```bash
- pip install -r requirements.txt
- ```
- 
--Then run the script:
-+When `pip install` is unavailable, the repository ships with a small stub
-+implementation located in the `openai/` folder. Running `python
-+assistant_python.py` from the project root automatically loads this stub so
-+the script still works offline and prints a placeholder response.
- 
- ```bash
- python assistant_python.py
- ```
- 
--It expects the `OPENAI_API_KEY` environment variable (and optionally
-+The script expects the `OPENAI_API_KEY` environment variable (and optionally
- `OPENAI_ASSISTANT_ID`) to be set, mirroring the Node example.
- 
- The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
- 
- Animations rely on simple CSS transitions, so no external libraries such as AOS are required.
+# CORE-IQ Demo
+
+This is a lightweight demo that displays audience insights by UK postcode or US ZIP code. Enter a code to see the relevant Experian Mosaic groups and media consumption indices.
+
+## Usage
+1. Install Node.js (v18 or newer is recommended). If you must use an older version, install the `node-fetch` package so the OpenAI requests work.
+2. Run `npm start` from the project root to launch a small local server.
+3. Open `http://localhost:8000` in your browser.
+4. Enter a postcode or search term to view the Mosaic groups and weighted media budget.
+
+### OpenAI integration
+To enable natural language queries processed via OpenAI, set environment variables `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` before starting the server:
+
+```bash
+export OPENAI_API_KEY=<your-api-key>
+export OPENAI_ASSISTANT_ID=<your-assistant-id>
+npm start
+```
+
+When a search term does not match local data, the server forwards the query to
+your configured OpenAI Assistant. Postcode lookups support partial codes like
+"EC1", and Mosaic group codes (such as "A" for City Prosperity) automatically
+map to their detailed JSON. The assistant handles these questions using the
+data uploaded to it.
+
+You can test the endpoint directly with `curl`:
+
+```bash
+curl -X POST http://localhost:8000/api/openai \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"Females in Cardiff"}'
+```
+
+The results page includes a **Core-IQ™ Insight** card that shows the OpenAI
+response for the most relevant Mosaic group. You can ask follow‑up questions in
+the card’s input field or use the **Ask Core-IQ** box on the home page to query
+the assistant directly. If the OpenAI request fails (for example, if the API
+key is missing or the network is down), a helpful error message appears instead.
+Server-side responses now check for OpenAI errors and return that message in an
+`error` field so the page can surface the issue.
+If you start the server without the required environment variables, the response
+will contain `{ "error": "Core-IQ service unavailable" }` to make troubleshooting
+clear.
+
+If the UI shows **"Core-IQ service unavailable"**, it usually means the page
+couldn't reach the local Node server or the server couldn't contact OpenAI. Make
+sure `npm start` is running and that your `.env` file contains valid
+`OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` values. When running without network
+access, execute `./setup.sh` first
+to install stub modules so the demo can still respond.
+
+### Python assistant script
+If you prefer using Python, the `assistant_python.py` utility demonstrates
+how to call an OpenAI Assistant. Install the requirement with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run the script:
+
+```bash
+python assistant_python.py
+```
+
+It expects the `OPENAI_API_KEY` environment variable (and optionally
+`OPENAI_ASSISTANT_ID`) to be set, mirroring the Node example.
+
+The application is static and loads JSON data client-side, so it can be embedded in other pages (for example, within a HubSpot iframe).
+
+Animations rely on simple CSS transitions, so no external libraries such as AOS are required.

--- a/city_to_postcodes.json
+++ b/city_to_postcodes.json
@@ -1,0 +1,5 @@
+{
+  "CARDIFF": ["CF"],
+  "BRISTOL": ["BS"],
+  "LONDON": ["EC", "SW"]
+}

--- a/main.js
+++ b/main.js
@@ -35,7 +35,16 @@ async function runSearch() {
     return r.json();
   });
 
-  Promise.all([postcodeData, areaData, cityPostcodeData, noticedData, helpfulData, responseData, featureData, groupData]).then(async ([data, area, cityCodes, noticed, helpful, response, features, groups]) => {
+  Promise.all([
+    postcodeData,
+    areaData,
+    cityPostcodeData,
+    noticedData,
+    helpfulData,
+    responseData,
+    featureData,
+    groupData,
+  ]).then(async ([data, area, cityCodes, noticed, helpful, response, features, groups]) => {
       const resultContainer = document.getElementById("resultContainer");
       resultContainer.classList.remove("hidden");
       resultContainer.innerHTML = "";

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ async function runSearch() {
   const postcode = query.replace(/\s+/g, "");
   const postcodeData = loadPostcodeData(postcode);
   const areaData = loadAreaMapping(query);
+  const cityPostcodeData = loadCityPostcodeEntries(query);
 
   const noticedData = fetch("noticed_adverts.json").then((r) => {
     if (!r.ok) throw new Error("Media file not found");
@@ -34,30 +35,40 @@ async function runSearch() {
     return r.json();
   });
 
-  Promise.all([postcodeData, areaData, noticedData, helpfulData, responseData, featureData, groupData]).then(async ([data, area, noticed, helpful, response, features, groups]) => {
+  Promise.all([postcodeData, areaData, cityPostcodeData, noticedData, helpfulData, responseData, featureData, groupData]).then(async ([data, area, cityCodes, noticed, helpful, response, features, groups]) => {
       const resultContainer = document.getElementById("resultContainer");
       resultContainer.classList.remove("hidden");
       resultContainer.innerHTML = "";
 
-      let entries = findPostcodeEntries(data, postcode);
-      if (!entries && Array.isArray(area)) {
-        entries = area;
-      }
-      if (!entries) {
+      let entries = [];
+      const pcEntries = findPostcodeEntries(data, postcode);
+      if (pcEntries) entries = entries.concat(pcEntries);
+      if (Array.isArray(area)) entries = entries.concat(area);
+      if (Array.isArray(cityCodes)) entries = entries.concat(cityCodes);
+      if (entries.length === 0) {
         searchVariable(query, resultContainer);
         return;
       }
+      entries = mergeEntries(entries);
+      const groupNames = Object.fromEntries(groups.map(g => [g.group_code, g.group_name]));
+      const groupsSorted = aggregateGroupCounts(entries);
       const topSegments = entries
         .filter((e) => e.type)
         .sort((a, b) => b.count - a.count)
         .slice(0, 3);
       const budget = parseFloat(document.getElementById("budgetInput").value) || 0;
 
-      let html = `<h2 class="result-heading">Insights for ${postcode}</h2>`;
+      let html = `<h2 class="result-heading">Insights for ${query}</h2>`;
       html += `<div class="summary-card">Total Media Budget: £${budget.toFixed(2)}</div>`;
       html += `<div class='card-wrap'>`;
 
-      // Area 1: Mosaic Segments
+      // Area 1: Mosaic Groups
+      html += groupsSorted
+        .slice(0, 3)
+        .map(g => `<div class="insight-card"><div class="insight-title">${g.code} - ${groupNames[g.code] || ''}</div><div class="insight-index">Count = ${g.count}</div></div>`)
+        .join("");
+
+      // Area 2: Mosaic Segments
       html += topSegments
         .map(
           (entry) => `
@@ -285,7 +296,6 @@ function determineBatchFile(postcode) {
 
 async function loadAreaMapping(query) {
   const files = [
-    'postcode_to_mosaic.json',
     'city_to_mosaic.json',
     'region_to_mosaic.json',
     'local_authority_to_mosaic.json'
@@ -297,11 +307,51 @@ async function loadAreaMapping(query) {
       if (!r.ok) continue;
       const data = await r.json();
       if (data[key]) return data[key];
+      const partialKey = Object.keys(data).find(k => k.includes(key));
+      if (partialKey) return data[partialKey];
     } catch (_) {
       // ignore
     }
   }
   return null;
+}
+
+async function loadCityPostcodes(city) {
+  try {
+    const r = await fetch('city_to_postcodes.json');
+    if (!r.ok) return [];
+    const data = await r.json();
+    return data[city.toUpperCase()] || [];
+  } catch (_) {
+    return [];
+  }
+}
+
+async function loadPrefixEntries(prefix) {
+  const file = `${determineBatchFile(prefix)}.json`;
+  try {
+    const r = await fetch(file);
+    if (!r.ok) return [];
+    const data = await r.json();
+    const entries = [];
+    for (const [pc, list] of Object.entries(data)) {
+      if (pc.startsWith(prefix)) entries.push(...list);
+    }
+    return entries;
+  } catch (_) {
+    return [];
+  }
+}
+
+async function loadCityPostcodeEntries(city) {
+  const prefixes = await loadCityPostcodes(city);
+  if (!Array.isArray(prefixes) || prefixes.length === 0) return [];
+  let results = [];
+  for (const pre of prefixes) {
+    const entries = await loadPrefixEntries(pre);
+    results = results.concat(entries);
+  }
+  return results;
 }
 
 function postcodeCandidates(postcode) {
@@ -322,6 +372,34 @@ function findPostcodeEntries(data, postcode) {
     if (data[c]) return data[c];
   }
   return null;
+}
+
+function mergeEntries(entries) {
+  const merged = new Map();
+  entries.forEach(e => {
+    if (!e || !e.type) return;
+    const key = e.type;
+    const count = e.count || 0;
+    if (!merged.has(key)) {
+      merged.set(key, { type: e.type, count });
+    } else {
+      merged.get(key).count += count;
+    }
+  });
+  return Array.from(merged.values());
+}
+
+function aggregateGroupCounts(entries) {
+  const totals = {};
+  entries.forEach(e => {
+    if (!e || !e.type) return;
+    const group = e.type.trim()[0];
+    const cnt = e.count || 0;
+    totals[group] = (totals[group] || 0) + cnt;
+  });
+  return Object.entries(totals)
+    .sort((a, b) => b[1] - a[1])
+    .map(([code, count]) => ({ code, count }));
 }
 
 async function loadPostcodeData(postcode) {

--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,69 +1,36 @@
-diff --git a//dev/null b/openai/__init__.py
-index 0000000000000000000000000000000000000000..d22945966d1e9e3bb9a7fb9f003f26b1fa621c76 100644
---- a//dev/null
-+++ b/openai/__init__.py
-@@ -0,0 +1,64 @@
-+class OpenAI:
-+    def __init__(self, api_key=None):
-+        self.api_key = api_key
-+        self.beta = self.Beta()
-+
-+    class Beta:
-+        def __init__(self):
-+            self.threads = self.Threads()
-+
-+        class Threads:
-+            def __init__(self):
-+                self.messages = self.Messages()
-+                self.runs = self.Runs()
-+
-+            def create(self):
-+                return type('Thread', (), {'id': 'thread-123'})()
-+
-+            class Messages:
-+                def create(self, thread_id, role=None, content=None):
-+                    return type(
-+                        'Message',
-+                        (),
-+                        {
-+                            'id': 'msg-123',
-+                            'thread_id': thread_id,
-+                            'role': role,
-+                            'content': content,
-+                        },
-+                    )()
-+
-+                def list(self, thread_id):
-+                    msg = type(
-+                        'Message',
-+                        (),
-+                        {
-+                            'role': 'assistant',
-+                            'content': [
-+                                type(
-+                                    'Content',
-+                                    (),
-+                                    {
-+                                        'text': type('Text', (), {'value': 'Stubbed response from OpenAI.'})()
-+                                    },
-+                                )()
-+                            ],
-+                        },
-+                    )
-+                    return type('MessagesList', (), {'data': [msg]})()
-+
-+            class Runs:
-+                def create(self, thread_id, assistant_id=None):
-+                    return type(
-+                        'Run',
-+                        (),
-+                        {
-+                            'id': 'run-123',
-+                            'thread_id': thread_id,
-+                            'assistant_id': assistant_id,
-+                            'status': 'completed',
-+                        },
-+                    )()
-+
-+                def retrieve(self, thread_id, run_id):
-+                    return type('Run', (), {'id': run_id, 'status': 'completed'})()
+class OpenAI:
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+        self.beta = self.Beta()
+
+    class Beta:
+        def __init__(self):
+            self.threads = self.Threads()
+
+        class Threads:
+            def __init__(self):
+                self.messages = self.Messages()
+                self.runs = self.Runs()
+
+            def create(self):
+                return type('Thread', (), {'id': 'thread-123'})()
+
+            class Messages:
+                def create(self, thread_id, role=None, content=None):
+                    return type('Message', (), {'id': 'msg-123', 'thread_id': thread_id, 'role': role, 'content': content})()
+
+                def list(self, thread_id):
+                    msg = type('Message', (), {
+                        'role': 'assistant',
+                        'content': [type('Content', (), {
+                            'text': type('Text', (), {'value': 'Stubbed response from OpenAI.'})()
+                        })()]
+                    })
+                    return type('MessagesList', (), {'data': [msg]})()
+
+            class Runs:
+                def create(self, thread_id, assistant_id=None):
+                    return type('Run', (), {'id': 'run-123', 'thread_id': thread_id, 'assistant_id': assistant_id, 'status': 'completed'})()
+
+                def retrieve(self, thread_id, run_id):
+                    return type('Run', (), {'id': run_id, 'status': 'completed'})()


### PR DESCRIPTION
## Summary
- map cities to postcode areas in new `city_to_postcodes.json`
- load postcode segments for those prefixes and merge with regular area results
- deduplicate segment entries before calculating results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861b43afeb0832da6d6ca751bb32daf