### PR TITLE
Fix search function by removing stray brace

### DIFF
--- a/main.js
+++ b/main.js
@@ -424,7 +424,6 @@ function aggregateGroupCounts(entries) {
     .sort((a, b) => b[1] - a[1])
     .map(([code, count]) => ({ code, count }));
 }
-}
 
 async function loadPostcodeData(postcode) {
   const primary = `${determineBatchFile(postcode)}.json`;


### PR DESCRIPTION
## Summary
- remove stray brace from `main.js` to eliminate syntax error

## Testing
- `node --check main.js`
- `node budget.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686276e74bd8832da0ee9b7d14dc5b67