### PR TITLE
Add ROI forecast calculation module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Demo for CORE-IQ audience insights",
   "main": "index.html",
   "scripts": {
-    "test": "node budget.test.js",
+    "test": "node budget.test.js && node roi.test.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/roi.js
+++ b/roi.js
@@ -1,0 +1,13 @@
+function calculateROIForecast({ budget = 0, unitPrice = 0, targetSales = 0, reach = 0 }) {
+  budget = parseFloat(budget) || 0;
+  unitPrice = parseFloat(unitPrice) || 0;
+  targetSales = parseFloat(targetSales) || 0;
+  reach = parseFloat(reach) || 0;
+  const totalRevenue = unitPrice * targetSales;
+  const requiredConversion = reach ? (targetSales / reach) * 100 : 0;
+  const roas = budget ? totalRevenue / budget : 0;
+  const netProfit = totalRevenue - budget;
+  return { requiredConversion, totalRevenue, netProfit, roas };
+}
+
+if (typeof module !== 'undefined') module.exports = { calculateROIForecast };

--- a/roi.test.js
+++ b/roi.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const { calculateROIForecast } = require('./roi');
+
+const res = calculateROIForecast({ budget: 1000, unitPrice: 50, targetSales: 30, reach: 10000 });
+assert(Math.abs(res.requiredConversion - 0.3) < 1e-6);
+assert.strictEqual(res.totalRevenue, 1500);
+assert.strictEqual(res.netProfit, 500);
+assert.strictEqual(res.roas, 1.5);
+
+console.log('ROI tests passed');


### PR DESCRIPTION
## Summary
- add `calculateROIForecast` helper to compute ROI metrics
- test ROI calculations via new `roi.test.js`
- run both budget and ROI tests via npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862cc3a81c8832daf1ba717c078ada5