### PR TITLE
Add ROI forecast and search filter UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,18 +74,19 @@
       <div style="display: flex; flex-direction: column; gap: 16px;">
         <input type="text" id="targetAreaInput" placeholder="Enter postcode, city or region" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
         <input type="number" id="budgetInput" placeholder="Budget (£)" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+        <input type="number" id="productPriceInput" placeholder="Product Unit Price" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+        <input type="number" id="servicePriceInput" placeholder="Service Unit Price" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+        <input type="number" id="salesInput" placeholder="Target Sales" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+        <input type="number" id="reachInput" placeholder="Reach Estimate" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+        <button id="roiButton" type="button" style="background: #00ffae; color: #000; font-weight: bold; font-size: 1rem; padding: 14px; border-radius: 12px; border: none; transition: background 0.3s;">CALCULATE ROI</button>
         <div style="display:flex;gap:8px;">
           <input id="openAIInput" placeholder="Ask Core-IQ" style="flex:1;padding:12px;border-radius:12px;border:none;font-size:1rem;background:#111;color:#fff;box-shadow:inset 0 0 6px rgba(0,255,174,0.2);" />
           <button id="openAIAskButton" type="button" style="background:#00ffae;color:#000;font-weight:bold;font-size:1rem;padding:12px;border-radius:12px;border:none;">Ask</button>
         </div>
-        <select id="incomeFilter" style="padding:12px;border-radius:12px;border:none;font-size:1rem;background:#111;color:#fff;">
-          <option value="">Any Income</option>
-          <option value="1">&lt;£20K</option>
-          <option value="2">£20K-£39K</option>
-          <option value="3">£40K-£59K</option>
-          <option value="4">£60K-£99K</option>
-          <option value="5">£100K+</option>
-        </select>
+        <label style="text-align:left;font-size:0.9rem;">Income Band:
+          <input type="range" id="incomeSlider" min="1" max="5" value="1" step="1" style="width:100%;" oninput="document.getElementById('incomeValue').textContent=this.value;" />
+          <span id="incomeValue">1</span>
+        </label>
         <div style="display:flex;gap:8px;align-items:center;">
           <input type="range" id="ageMin" min="18" max="80" value="18" style="flex:1;" />
           <input type="range" id="ageMax" min="18" max="80" value="80" style="flex:1;" />
@@ -109,9 +110,11 @@
         <button id="submitButton" type="button" style="background: #00ffae; color: #000; font-weight: bold; font-size: 1rem; padding: 14px; border-radius: 12px; border: none; transition: background 0.3s;">GET INSIGHTS</button>
       </div>
       <div id="resultContainer" class="hidden"></div>
+      <div id="roiContainer" style="display:none;margin-top:20px;background:#111;padding:24px;border-radius:12px;box-shadow:0 0 16px rgba(0,255,174,0.3);"></div>
     </div>
   </section>
 
+  <script src="roi.js"></script>
   <script src="budget.js"></script>
   <script src="main.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Demo for CORE-IQ audience insights",
   "main": "index.html",
   "scripts": {
-    "test": "node budget.test.js",
+    "test": "node budget.test.js && node roi.test.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/results.html
+++ b/results.html
@@ -30,14 +30,15 @@
     <div style="width:100%; max-width:540px; margin:auto; display:flex; flex-direction:column; gap:16px;">
       <input type="text" id="targetAreaInput" placeholder="Enter postcode, city or region" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
       <input type="number" id="budgetInput" placeholder="Budget (£)" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-      <select id="incomeFilter" style="padding:12px;border-radius:12px;border:none;font-size:1rem;background:#111;color:#fff;">
-        <option value="">Any Income</option>
-        <option value="1">&lt;£20K</option>
-        <option value="2">£20K-£39K</option>
-        <option value="3">£40K-£59K</option>
-        <option value="4">£60K-£99K</option>
-        <option value="5">£100K+</option>
-      </select>
+      <input type="number" id="productPriceInput" placeholder="Product Unit Price" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+      <input type="number" id="servicePriceInput" placeholder="Service Unit Price" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+      <input type="number" id="salesInput" placeholder="Target Sales" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+      <input type="number" id="reachInput" placeholder="Reach Estimate" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
+      <button id="roiButton" type="button" style="background:#00ffae; color:#000; font-weight:bold; font-size:1rem; padding:14px; border-radius:12px; border:none; transition:background 0.3s;">CALCULATE ROI</button>
+      <label style="text-align:left;font-size:0.9rem;">Income Band:
+        <input type="range" id="incomeSlider" min="1" max="5" value="1" step="1" style="width:100%;" oninput="document.getElementById('incomeValue').textContent=this.value;" />
+        <span id="incomeValue">1</span>
+      </label>
       <div style="display:flex;gap:8px;align-items:center;">
         <input type="range" id="ageMin" min="18" max="80" value="18" style="flex:1;" />
         <input type="range" id="ageMax" min="18" max="80" value="80" style="flex:1;" />
@@ -65,9 +66,11 @@
 
   <section id="resultsSection" style="background: linear-gradient(to bottom, #000, #0a0a0a); min-height: 100vh; padding: 60px 20px;">
     <div id="resultsRoot" style="max-width: 1200px; margin: auto; display: flex; flex-direction: column; gap: 40px;"></div>
+    <div id="roiContainer" style="max-width: 600px; margin: 40px auto; display:none; background:#111; padding:24px; border-radius:12px; box-shadow:0 0 16px rgba(0,255,174,0.3);"></div>
   </section>
 
   <script src="results.js"></script>
+  <script src="roi.js"></script>
   <script src="budget.js"></script>
   <script src="main.js"></script>
   <script src="chat.js"></script>

--- a/results.js
+++ b/results.js
@@ -39,6 +39,7 @@ function renderAudienceResults(data) {
         `).join('')}
       </div>
     </div>
+    ${Array.isArray(data.type_breakdown) ? `<div><h3 style="color:#00ffae;text-align:center;">Mosaic Type Breakdown</h3><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px;">${data.type_breakdown.map((t,i)=>{const color=t.percent<25?'red':'#00ffae';const border=i===0?'4px solid #00ffae':'none';return `<div style=\"background:#111;border-radius:12px;padding:16px;border-left:${border};\"><p style=\"margin:0;color:${color};font-weight:600;\">${t.type}</p><p style=\"margin:0;color:${color};\">${t.percent.toFixed(0)}%</p></div>`}).join('')}</div></div>`:''}
     ${Array.isArray(data.ranked_groups) ? `<div><h3 style="color:#00ffae;text-align:center;">All Mosaic Groups</h3><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:16px;">${data.ranked_groups.map(g => `<div style="background:#111;border-radius:12px;padding:16px;border-left:4px solid #00ffae;"><p style="margin:0;font-weight:600;">${g.code} - ${g.name}</p><p style="margin:0;color:#ccc;">Score ${(g.score*100).toFixed(0)}</p></div>`).join('')}</div></div>` : ''}
     ${data.household_technology ? `<div style="background:#111;border-radius:12px;padding:24px;box-shadow:0 0 16px rgba(0,255,174,0.3);text-align:center;"><p style="margin:0;color:#ccc;">Household Technology Level</p><p style="margin:0;font-size:1.2rem;color:#00ffae;font-weight:600;">${data.household_technology}</p></div>` : ''}
     ${Array.isArray(data.noticed_channels) && data.noticed_channels.length ? `<div><h3 style="font-size:1.5rem;font-weight:700;color:#00ffae;">Advertising Mediums Noticed</h3><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:24px;margin-top:20px;">${data.noticed_channels.map(r => { const high = r.index >= 100; const color = high ? '#00ffae' : 'red'; const shadow = high ? '0 0 24px rgba(0,255,174,0.5)' : '0 0 24px rgba(255,0,0,0.5)'; return `<div style="background:#111;border-radius:12px;padding:20px;text-align:center;box-shadow:${shadow};"><p style="margin:0;color:#ccc;">${r.channel}</p><p style="color:${color};font-weight:bold;">${r.index}</p></div>`; }).join('')}</div></div>` : ''}
@@ -192,3 +193,27 @@ if (stored) {
 } else {
   fetch('sample_result.json').then(r => r.json()).then(data => renderAudienceResults(data));
 }
+
+function setupROICalc() {
+  const btn = document.getElementById('roiButton');
+  const container = document.getElementById('roiContainer');
+  if (!btn || !container) return;
+  btn.addEventListener('click', () => {
+    container.style.display = 'block';
+    const budget = document.getElementById('budgetInput').value;
+    const productPrice = document.getElementById('productPriceInput').value;
+    const servicePrice = document.getElementById('servicePriceInput').value;
+    const targetSales = document.getElementById('salesInput').value;
+    const reach = document.getElementById('reachInput').value;
+    const res = calculateROIForecast({ budget, productPrice, servicePrice, targetSales, reach });
+    container.innerHTML = `
+      <h3 style="color:#00ffae;text-align:center;margin-top:0;">ROI Forecast</h3>
+      <p style="margin:0;color:#ccc;">Required Conversion: ${res.requiredConversion.toFixed(2)}%</p>
+      <p style="margin:0;color:#ccc;">Total Revenue: £${res.totalRevenue.toFixed(2)}</p>
+      <p style="margin:0;color:#ccc;">Net Profit: £${res.netProfit.toFixed(2)}</p>
+      <p style="margin:0;color:#ccc;">ROAS: ${res.roas.toFixed(2)}x</p>
+    `;
+  });
+}
+
+setupROICalc();

--- a/roi.js
+++ b/roi.js
@@ -1,0 +1,25 @@
+// Calculate ROI forecast using either product or service pricing.
+// Any missing values default to zero so the function is safe to call
+// with partially filled forms.
+function calculateROIForecast({
+  budget = 0,
+  productPrice = 0,
+  servicePrice = 0,
+  targetSales = 0,
+  reach = 0
+}) {
+  budget = parseFloat(budget) || 0;
+  productPrice = parseFloat(productPrice) || 0;
+  servicePrice = parseFloat(servicePrice) || 0;
+  targetSales = parseFloat(targetSales) || 0;
+  reach = parseFloat(reach) || 0;
+  // Use whichever price values are supplied. If both are given they are summed.
+  const unitPrice = productPrice + servicePrice;
+  const totalRevenue = unitPrice * targetSales;
+  const requiredConversion = reach ? (targetSales / reach) * 100 : 0;
+  const roas = budget ? totalRevenue / budget : 0;
+  const netProfit = totalRevenue - budget;
+  return { requiredConversion, totalRevenue, netProfit, roas };
+}
+
+if (typeof module !== 'undefined') module.exports = { calculateROIForecast };

--- a/roi.test.js
+++ b/roi.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const { calculateROIForecast } = require('./roi');
+
+const res = calculateROIForecast({
+  budget: 1000,
+  productPrice: 40,
+  servicePrice: 10,
+  targetSales: 30,
+  reach: 10000
+});
+assert(Math.abs(res.requiredConversion - 0.3) < 1e-6);
+assert.strictEqual(res.totalRevenue, 1500);
+assert.strictEqual(res.netProfit, 500);
+assert.strictEqual(res.roas, 1.5);
+
+console.log('ROI tests passed');


### PR DESCRIPTION
## Summary
- expose ROI fields on search and results pages
- compute ROI forecast client-side
- show Mosaic Type breakdown with top type highlighted
- fix ROI container display so it's only visible after calculation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862cc3a81c8832daf1ba717c078ada5