### PR TITLE
Update search UI per instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,22 +75,15 @@
         <input type="text" id="targetAreaInput" placeholder="Enter postcode, city or region" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
         <input type="number" id="budgetInput" placeholder="Budget (£)" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
         <input type="number" id="productPriceInput" placeholder="Product Unit Price" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-        <input type="number" id="servicePriceInput" placeholder="Service Unit Price" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-        <input type="number" id="salesInput" placeholder="Target Sales" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-        <input type="number" id="reachInput" placeholder="Reach Estimate" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-        <button id="roiButton" type="button" style="background: #00ffae; color: #000; font-weight: bold; font-size: 1rem; padding: 14px; border-radius: 12px; border: none; transition: background 0.3s;">CALCULATE ROI</button>
+        <input type="number" id="salesInput" placeholder="Required QTY of Sales" style="padding: 16px; border-radius: 12px; border: none; font-size: 1rem; background: #111; color: #fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
         <div style="display:flex;gap:8px;">
           <input id="openAIInput" placeholder="Ask Core-IQ" style="flex:1;padding:12px;border-radius:12px;border:none;font-size:1rem;background:#111;color:#fff;box-shadow:inset 0 0 6px rgba(0,255,174,0.2);" />
           <button id="openAIAskButton" type="button" style="background:#00ffae;color:#000;font-weight:bold;font-size:1rem;padding:12px;border-radius:12px;border:none;">Ask</button>
         </div>
         <label style="text-align:left;font-size:0.9rem;">Income Band:
-          <input type="range" id="incomeSlider" min="1" max="5" value="1" step="1" style="width:100%;" oninput="document.getElementById('incomeValue').textContent=this.value;" />
-          <span id="incomeValue">1</span>
+          <input type="range" id="incomeSlider" min="10000" max="100000" value="10000" step="1000" style="width:100%;accent-color:#00ff00;" oninput="document.getElementById('incomeValue').textContent="£"+(this.value/1000)+"K";" />
+          <span id="incomeValue">£10K</span>
         </label>
-        <div style="display:flex;gap:8px;align-items:center;">
-          <input type="range" id="ageMin" min="18" max="80" value="18" style="flex:1;" />
-          <input type="range" id="ageMax" min="18" max="80" value="80" style="flex:1;" />
-        </div>
         <select id="childrenFilter" style="padding:12px;border-radius:12px;border:none;font-size:1rem;background:#111;color:#fff;">
           <option value="">Any Children</option>
           <option value="0">0</option>

--- a/results.html
+++ b/results.html
@@ -31,18 +31,11 @@
       <input type="text" id="targetAreaInput" placeholder="Enter postcode, city or region" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
       <input type="number" id="budgetInput" placeholder="Budget (£)" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
       <input type="number" id="productPriceInput" placeholder="Product Unit Price" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-      <input type="number" id="servicePriceInput" placeholder="Service Unit Price" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-      <input type="number" id="salesInput" placeholder="Target Sales" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-      <input type="number" id="reachInput" placeholder="Reach Estimate" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
-      <button id="roiButton" type="button" style="background:#00ffae; color:#000; font-weight:bold; font-size:1rem; padding:14px; border-radius:12px; border:none; transition:background 0.3s;">CALCULATE ROI</button>
+      <input type="number" id="salesInput" placeholder="Required QTY of Sales" style="padding:16px; border-radius:12px; border:none; font-size:1rem; background:#111; color:#fff; box-shadow: inset 0 0 6px rgba(0,255,174,0.2);" />
       <label style="text-align:left;font-size:0.9rem;">Income Band:
-        <input type="range" id="incomeSlider" min="1" max="5" value="1" step="1" style="width:100%;" oninput="document.getElementById('incomeValue').textContent=this.value;" />
-        <span id="incomeValue">1</span>
+        <input type="range" id="incomeSlider" min="10000" max="100000" value="10000" step="1000" style="width:100%;accent-color:#00ff00;" oninput="document.getElementById('incomeValue').textContent="£"+(this.value/1000)+"K";" />
+        <span id="incomeValue">£10K</span>
       </label>
-      <div style="display:flex;gap:8px;align-items:center;">
-        <input type="range" id="ageMin" min="18" max="80" value="18" style="flex:1;" />
-        <input type="range" id="ageMax" min="18" max="80" value="80" style="flex:1;" />
-      </div>
       <select id="childrenFilter" style="padding:12px;border-radius:12px;border:none;font-size:1rem;background:#111;color:#fff;">
         <option value="">Any Children</option>
         <option value="0">0</option>


### PR DESCRIPTION
## Summary
- remove service price field, ROI button and reach estimate input
- show income slider in green with values from 10k to 100k
- rename target sales placeholder to `Required QTY of Sales`
- drop age sliders from search forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639bf1d110832d92d843dd98cd79d9